### PR TITLE
refactor the build system -- use exported cmake targets instead of ma…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
-project(feh)
+
+# vision lab visual-inertial navigation system
+project(vl_vins)
 
 # Set operating system variables
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
@@ -43,24 +45,34 @@ add_definitions(-DGOOGLE_STRIP_LOG=1)
 # add_definitions(-DEIGEN_DEFAULT_TO_ROW_MAJOR)
 add_definitions(-DEIGEN_INITIALIZE_MATRICES_BY_ZERO)
 
-list(APPEND CMAKE_PREFIX_PATH ${CMAKE_SOURCE_DIR}/thirdparty)
+set(THIRD_PARTY_DIR "${CMAKE_SOURCE_DIR}/thirdparty")
+list(APPEND CMAKE_PREFIX_PATH ${THIRD_PARTY_DIR})
 
-# Find and add OpenCV to libraries
-find_package(OpenCV REQUIRED)
+find_package(OpenCV REQUIRED PATHS ${THIRD_PARTY_DIR}/opencv/install)
 find_package(Python3 REQUIRED Interpreter Development)
 find_package(Pangolin REQUIRED)
 find_package(jsoncpp REQUIRED)
+
 # Google stuff
 find_package(gflags REQUIRED)
 find_package(GTest REQUIRED NAMES GTest gtest googletest GoogleTest)
 find_package(glog REQUIRED)
 find_package(Ceres REQUIRED)
-# Find and add DBoW2 
+
+# DBoW2 
 find_package(DBoW2 REQUIRED)
-# Create an interface target for DBoW2 (since DBoW2 does not export headers & libraries as a target)
+# Create an interface target for DBoW2 (since DBoW2 does not export headers & libraries as a target).
+# We will add the DBoW2 target to our dependency list in a bit.
 add_library(DBoW2 INTERFACE)
 target_include_directories(DBoW2 INTERFACE ${DBoW2_INCLUDE_DIR})
 target_link_libraries(DBoW2 INTERFACE ${DBoW2_LIBS})
+
+# The dependency PNP does not properly export a target for easy integration,
+# so we create an interface target here, and will add the interface target to 
+# the dependency list in a bit.
+add_library(pnp INTERFACE)
+target_include_directories(pnp INTERFACE ${THIRD_PARTY_DIR}/pnp)
+target_link_libraries(pnp INTERFACE ${THIRD_PARTY_DIR}/pnp/build/liblibpnp.a)
 
 # TODO (xiaohfei): this is not working since gperftools does not properly generate cmake config files.
 # Need to manually add gperftools if needed.
@@ -68,13 +80,9 @@ if (USE_GPERFTOOLS)
   find_package(gperftools REQUIRED)
 endif()
 
-# The dependency PNP does have proper installation target, need to manually specify paths.
-add_library(pnp INTERFACE)
-target_include_directories(pnp INTERFACE ${CMAKE_SOURCE_DIR}/thirdparty/pnp)
-target_link_libraries(pnp INTERFACE ${CMAKE_SOURCE_DIR}/thirdparty/pnp/build/liblibpnp.a)
 
 list(APPEND DEPS
-  # opencv
+  # OpenCV
   opencv_highgui
   opencv_features2d
   opencv_core
@@ -82,62 +90,46 @@ list(APPEND DEPS
   opencv_imgproc
   opencv_imgcodecs
   opencv_xfeatures2d
-  # google stuff
+
+  # Google stuff
   glog::glog
   GTest::gtest
   GTest::gtest_main
   GTest::gmock
   GTest::gmock_main
   gflags_static
-  # graphics
-  GLEW
-  pangolin
-  # solver
+
+  # Ceres::ceres should carry over all its own dependencies, so we don't need 
+  # to add the following dependencies: cxsparse, cholmod, lapack, and blas. 
+  # But if needed, you can add them back.
   Ceres::ceres
-  pnp
-  cxsparse
-  cholmod
-  lapack
-  blas
-  # utils
-  jsoncpp_lib
+
   # Use jsoncpp_static if you are building modules of xivo as static libraryies
   # jsoncpp_static
+  jsoncpp_lib
+
+  # Target "pangolin" exported by Pangolin should carry over its own dependencies, i.e., 
+  # GLEW and GL (in Linux). If needed, you can manually add them.
+  pangolin
+
+  # Loop closure dependencies. 
+  pnp
   DBoW2
-  # system
-  pthread
 )
-if (IS_LINUX)
-  list(APPEND DEPS GL)
-endif (IS_LINUX)
 
 link_libraries(${DEPS})
 
-# Manually add link directories (ideally we dont have to use this)
-link_directories(
-  /usr/local/lib
-  /usr/lib/x86_64-linux-gnu
-)
 
 include_directories(
   ${CMAKE_SOURCE_DIR}/common
   ${CMAKE_SOURCE_DIR}/src
-  # Manually add include dirs, ideally we don't need this
-  # ${JSONCPP_INCLUDE_DIRS}
-  # ${OpenCV_INCLUDE_DIRS}
-  # ${Python3_INCLUDE_DIRS}
-  /usr/include/suitesparse
-  /usr/include
 )
 
-
-
 enable_testing()
-# add_subdirectory(thirdparty/abseil-cpp)
 if (BUILD_G2O)
-  link_directories(${CMAKE_SOURCE_DIR}/thirdparty/g2o/release/lib)
-  include_directories(${CMAKE_SOURCE_DIR}/thirdparty/g2o/release/include)
-  list(APPEND deps
+  link_directories(${THIRD_PARTY_DIR}/g2o/release/lib)
+  include_directories(${THIRD_PARTY_DIR}/g2o/release/include)
+  link_libraries(
     g2o_core
     g2o_solver_dense
     g2o_solver_cholmod
@@ -146,12 +138,9 @@ if (BUILD_G2O)
     g2o_types_slam3d
     g2o_types_sba
     g2o_stuff
-    cholmod
-    cxsparse
-    )
+)
 endif(BUILD_G2O)
 
-# feh
 add_subdirectory(common)
 add_subdirectory(src)
 
@@ -166,10 +155,10 @@ add_subdirectory(src)
 # If you see an error saying "Python.h: No such file or directory", you probably
 # need to "sudo apt-get install python3-dev" assuming you are binding to python3.
 set(PYBIND11_CPP_STANDARD -std=c++17)
-add_subdirectory(thirdparty/pybind11)
+add_subdirectory(${THIRD_PARTY_DIR}/pybind11)
 pybind11_add_module(pyxivo MODULE pybind11/pyxivo.cpp)
-set(libxivo common xest xapp)
+set(pybind_deps common xest xapp)
 if (BUILD_G2O)
-  list(APPEND libxivo xopt)
+  list(APPEND pybind_deps xopt)
 endif(BUILD_G2O)
-target_link_libraries(pyxivo PRIVATE ${libxivo})
+target_link_libraries(pyxivo PRIVATE ${pybind_deps})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,9 +22,10 @@ if (BUILD_G2O)
   add_definitions(-DUSE_G2O)
 endif (BUILD_G2O)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -std=c++17 -Wno-narrowing -Wno-register -fPIC -g")
+set(CMAKE_CXX_STANDARD 17)
+# TODO (xiaohfei): We should turn on -Wall and -Werror to eliminate all the warnings.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -Wno-narrowing -Wno-register -fPIC -g")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mtune=native -march=native")
-
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -funroll-loops")
 
 # set(CMAKE_BUILD_TYPE "Debug")
@@ -42,55 +43,100 @@ add_definitions(-DGOOGLE_STRIP_LOG=1)
 # add_definitions(-DEIGEN_DEFAULT_TO_ROW_MAJOR)
 add_definitions(-DEIGEN_INITIALIZE_MATRICES_BY_ZERO)
 
+list(APPEND CMAKE_PREFIX_PATH ${CMAKE_SOURCE_DIR}/thirdparty)
+
+# Find and add OpenCV to libraries
 find_package(OpenCV REQUIRED)
 find_package(Python3 REQUIRED Interpreter Development)
+find_package(Pangolin REQUIRED)
+find_package(jsoncpp REQUIRED)
+# Google stuff
+find_package(gflags REQUIRED)
+find_package(GTest REQUIRED NAMES GTest gtest googletest GoogleTest)
+find_package(glog REQUIRED)
+find_package(Ceres REQUIRED)
+# Find and add DBoW2 
+find_package(DBoW2 REQUIRED)
+# Create an interface target for DBoW2 (since DBoW2 does not export headers & libraries as a target)
+add_library(DBoW2 INTERFACE)
+target_include_directories(DBoW2 INTERFACE ${DBoW2_INCLUDE_DIR})
+target_link_libraries(DBoW2 INTERFACE ${DBoW2_LIBS})
 
-link_directories(
-        ${PROJECT_SOURCE_DIR}/lib
-        ${PROJECT_SOURCE_DIR}/thirdparty/gflags/lib
-        ${PROJECT_SOURCE_DIR}/thirdparty/glog/lib
-        ${PROJECT_SOURCE_DIR}/thirdparty/Pangolin/lib
-        ${PROJECT_SOURCE_DIR}/thirdparty/jsoncpp/lib
-        ${PROJECT_SOURCE_DIR}/thirdparty/gperftools/lib
-        ${PROJECT_SOURCE_DIR}/thirdparty/DBoW2/lib
-        ${PROJECT_SOURCE_DIR}/thirdparty/pnp/build
-        ${PROJECT_SOURCE_DIR}/thirdparty/ceres-solver/lib
-        /usr/local/lib
+# TODO (xiaohfei): this is not working since gperftools does not properly generate cmake config files.
+# Need to manually add gperftools if needed.
+if (USE_GPERFTOOLS)
+  find_package(gperftools REQUIRED)
+endif()
+
+# The dependency PNP does have proper installation target, need to manually specify paths.
+add_library(pnp INTERFACE)
+target_include_directories(pnp INTERFACE ${CMAKE_SOURCE_DIR}/thirdparty/pnp)
+target_link_libraries(pnp INTERFACE ${CMAKE_SOURCE_DIR}/thirdparty/pnp/build/liblibpnp.a)
+
+list(APPEND DEPS
+  # opencv
+  opencv_highgui
+  opencv_features2d
+  opencv_core
+  opencv_video
+  opencv_imgproc
+  opencv_imgcodecs
+  opencv_xfeatures2d
+  # google stuff
+  glog::glog
+  GTest::gtest
+  GTest::gtest_main
+  GTest::gmock
+  GTest::gmock_main
+  gflags_static
+  # graphics
+  GLEW
+  pangolin
+  # solver
+  Ceres::ceres
+  pnp
+  cxsparse
+  cholmod
+  lapack
+  blas
+  # utils
+  jsoncpp_lib
+  # Use jsoncpp_static if you are building modules of xivo as static libraryies
+  # jsoncpp_static
+  DBoW2
+  # system
+  pthread
 )
 if (IS_LINUX)
-  link_directories(/usr/lib/x86_64-linux-gnu)
-endif(IS_LINUX)
+  list(APPEND DEPS GL)
+endif (IS_LINUX)
 
+link_libraries(${DEPS})
+
+# Manually add link directories (ideally we dont have to use this)
+link_directories(
+  /usr/local/lib
+  /usr/lib/x86_64-linux-gnu
+)
 
 include_directories(
-        ${PROJECT_SOURCE_DIR}/common
-        ${PROJECT_SOURCE_DIR}/src
-        ${PROJECT_SOURCE_DIR}/thirdparty/gflags/include
-        ${PROJECT_SOURCE_DIR}/thirdparty/glog/include
-        ${PROJECT_SOURCE_DIR}/thirdparty/Pangolin/include
-        ${PROJECT_SOURCE_DIR}/thirdparty/jsoncpp/include
-        ${PROJECT_SOURCE_DIR}/thirdparty/eigen/include/eigen3
-        ${PROJECT_SOURCE_DIR}/thirdparty/gperftools/include
-        ${PROJECT_SOURCE_DIR}/thirdparty/pybind11/include
-        ${PROJECT_SOURCE_DIR}/thirdparty/DBoW2/include
-        ${PROJECT_SOURCE_DIR}/thirdparty/pnp
-        ${JSONCPP_INCLUDE_DIRS}
-        /usr/include/suitesparse
-        /usr/include
-        ${OpenCV_INCLUDE_DIRS}
-        ${Python3_INCLUDE_DIRS}
+  ${CMAKE_SOURCE_DIR}/common
+  ${CMAKE_SOURCE_DIR}/src
+  # Manually add include dirs, ideally we don't need this
+  # ${JSONCPP_INCLUDE_DIRS}
+  # ${OpenCV_INCLUDE_DIRS}
+  # ${Python3_INCLUDE_DIRS}
+  /usr/include/suitesparse
+  /usr/include
 )
 
 
 
 enable_testing()
-add_subdirectory(thirdparty/googletest)
-add_subdirectory(thirdparty/gflags)
-include_directories(${PROJECT_SOURCE_DIR}/thirdparty/googletest/include)
 # add_subdirectory(thirdparty/abseil-cpp)
 if (BUILD_G2O)
-  link_directories(${PROJECT_SOURCE_DIR}/thirdparty/g2o/release/lib)
-  include_directories(${PROJECT_SOURCE_DIR}/thirdparty/g2o/release/include)
+  link_directories(${CMAKE_SOURCE_DIR}/thirdparty/g2o/release/lib)
+  include_directories(${CMAKE_SOURCE_DIR}/thirdparty/g2o/release/include)
   list(APPEND deps
     g2o_core
     g2o_solver_dense

--- a/build.sh
+++ b/build.sh
@@ -34,7 +34,8 @@ if [ $USE_GPERFTOOLS = true ]; then
 fi
 
 CPU_COUNT=4
-OPENCV_INSTALL_DIR=/media/data3/stsuei/DevelopmentEnvironments/xivo_gcc9/share/OpenCV
+# OPENCV_INSTALL_DIR=/media/data3/stsuei/DevelopmentEnvironments/xivo_gcc9/share/OpenCV
+OPENCV_INSTALL_DIR=$PWD/thirdparty/opencv/install/share/OpenCV
 
 # build dependencies
 PROJECT_DIR=$(pwd)

--- a/build.sh
+++ b/build.sh
@@ -34,8 +34,7 @@ if [ $USE_GPERFTOOLS = true ]; then
 fi
 
 CPU_COUNT=4
-# OPENCV_INSTALL_DIR=/media/data3/stsuei/DevelopmentEnvironments/xivo_gcc9/share/OpenCV
-OPENCV_INSTALL_DIR=$PWD/thirdparty/opencv/install/share/OpenCV
+OPENCV_INSTALL_DIR=/media/data3/stsuei/DevelopmentEnvironments/xivo_gcc9/share/OpenCV
 
 # build dependencies
 PROJECT_DIR=$(pwd)

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -6,7 +6,6 @@ project(common)
 # set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/lib)
 
 add_library(common STATIC utils.cpp)
-target_link_libraries(common pthread)
 
 # option(BUILD_COMMON_TESTS True)
 # if (${BUILD_COMMON_TESTS})

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -1,10 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 project(common)
 
-# # uncomment to overwrite target destinations
-# set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/bin)
-# set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/lib)
-
 add_library(common STATIC utils.cpp)
 
 # option(BUILD_COMMON_TESTS True)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,8 +3,8 @@ cmake_minimum_required(VERSION 3.5)
 project(estimator)
 
 # # overwrite binary output directory
-# set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/bin)
-# set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/lib)
+# set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bin)
+# set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/lib)
 
 # if set, use inverse-depth parametrization
 # add_definitions(-DUSE_INVDEPTH)
@@ -28,44 +28,8 @@ add_definitions(-DUSE_ONLINE_CAMERA_CALIB)
 # rid of accumulated numeric error
 #add_definitions(-DENFORCE_SO3_FREQ=50)
 
-include_directories(
-  ${PROJECT_SOURCE_DIR}
-  ${CMAKE_SOURCE_DIR}/common)
 
-link_directories(
-  ${CMAKE_SOURCE_DIR}/lib)
-
-list(APPEND deps
-        opencv_highgui
-        opencv_features2d
-        opencv_core
-        opencv_video
-        opencv_imgproc
-        opencv_imgcodecs
-        opencv_xfeatures2d
-        glog
-        GLEW
-        pangolin
-        pthread
-        jsoncpp
-        DBoW2
-        libpnp
-        common
-        ceres
-        cxsparse
-        cholmod
-        lapack
-        blas
-        )
-if (IS_LINUX)
-  list(APPEND deps GL)
-endif (IS_LINUX)
-
-if (USE_GPERFTOOLS)
-  list(APPEND deps profiler)
-endif (USE_GPERFTOOLS)
-
-add_library(xapp STATIC
+add_library(xapp SHARED
         estimator_process.cpp
         loader.cpp
         geometry.cpp
@@ -73,9 +37,10 @@ add_library(xapp STATIC
         publisher.cpp
         graphwriter.cpp
         viewer.cpp)
-target_link_libraries(xapp ${deps})
+target_link_libraries(xapp PUBLIC common)
 
-add_library(xest STATIC
+
+add_library(xest SHARED
         factory.cpp
         estimator.cpp
         princedormand.cpp
@@ -97,25 +62,24 @@ add_library(xest STATIC
         mapper.cpp
         camera_manager.cpp
         imu.cpp)
+target_link_libraries(xest PUBLIC common)
 if (IS_MAC)
-  target_link_libraries(xest INTERFACE ${deps} "-Wl, -framework OpenGL")
-elseif (IS_LINUX)
-  target_link_libraries(xest INTERFACE ${deps})
+  target_compile_options(xest "-Wl, -framework OpenGL")
 endif()
 
 set(libxivo xest xapp)
 
 if (BUILD_G2O)
-  add_library(xopt STATIC
+  add_library(xopt SHARED
     optimizer.cpp
     optimizer_adapters.cpp
   )
-  target_link_libraries(xopt xest ${deps})
+  target_link_libraries(xopt xest)
   list(APPEND libxivo xopt)
 endif(BUILD_G2O)
 
 add_executable(vio app/vio.cpp)
-target_link_libraries(vio ${libxivo} gflags::gflags)
+target_link_libraries(vio ${libxivo})
 
 ################################################################################
 # TOOLING
@@ -129,39 +93,39 @@ target_link_libraries(vio ${libxivo} gflags::gflags)
 add_executable(unitTests_NumericalAlgorithms 
                test/unittest_givens.cpp
                test/unittest_helpers.cpp)
-target_link_libraries(unitTests_NumericalAlgorithms xest ${deps} gtest gtest_main)
+target_link_libraries(unitTests_NumericalAlgorithms xest)
 add_test(NAME NumericalAlgorithms COMMAND unitTests_NumericalAlgorithms)
 
 add_executable(unitTests_Jacobians
                test/unittest_jacobians_instate.cpp
                test/unittest_jacobians_oos.cpp
                test/unittest_helpers.cpp)
-target_link_libraries(unitTests_Jacobians ${libxivo} ${deps} gtest gtest_main)
+target_link_libraries(unitTests_Jacobians ${libxivo})
 add_test(NAME Jacobians COMMAND unitTests_Jacobians)
 
 add_executable(unitTests_Rodrigues
                test/unittest_rodrigues.cpp)
-target_link_libraries(unitTests_Rodrigues xest ${deps} gtest gtest_main)
+target_link_libraries(unitTests_Rodrigues xest)
 add_test(NAME Rodrigues COMMAND unitTests_Rodrigues)
 
 add_executable(unitTests_pinhole
                test/unittest_camera_pinhole.cpp)
-target_link_libraries(unitTests_pinhole xest ${deps} gtest gtest_main)
+target_link_libraries(unitTests_pinhole xest)
 add_test(NAME CamerasPinhole COMMAND unitTests_pinhole)
 
 add_executable(unitTests_radtan
                test/unittest_camera_radtan.cpp)
-target_link_libraries(unitTests_radtan xest ${deps} gtest gtest_main)
+target_link_libraries(unitTests_radtan xest)
 add_test(NAME CamerasRadtan COMMAND unitTests_radtan)
 
 add_executable(unitTests_equi
                test/unittest_camera_equi.cpp)
-target_link_libraries(unitTests_equi xest ${deps} gtest gtest_main)
+target_link_libraries(unitTests_equi xest)
 add_test(NAME CamerasEqui COMMAND unitTests_equi)
 
 add_executable(unitTests_atan
                test/unittest_camera_atan.cpp)
-target_link_libraries(unitTests_atan xest ${deps} gtest gtest_main)
+target_link_libraries(unitTests_atan xest)
 add_test(NAME CamerasAtan COMMAND unitTests_atan)
 
 if (BUILD_G2O)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,10 +2,6 @@ cmake_minimum_required(VERSION 3.5)
 
 project(estimator)
 
-# # overwrite binary output directory
-# set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bin)
-# set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/lib)
-
 # if set, use inverse-depth parametrization
 # add_definitions(-DUSE_INVDEPTH)
 


### PR DESCRIPTION
The current build system manually specifies path to the include/library directories. This is not portable.
For instance, on Fedora, the shared libraries (of the 3rd dependencies) will be installed in directory lib64 instead of lib.

In this PR, I removed some of the hardcoded paths, and used find_package and linked XIVO's targets against targets exported by the installed third-party libraries.