### PR TITLE
Added triangulation methods

### DIFF
--- a/cfg/phab.json
+++ b/cfg/phab.json
@@ -133,7 +133,7 @@
 
   // pre-subfilter triangulation options
   "triangulation": {
-    "method": 5,
+    "method": "linf_angular",
     "zmin": 0.05,
     "zmax": 5.0
   },

--- a/cfg/phab.json
+++ b/cfg/phab.json
@@ -133,7 +133,7 @@
 
   // pre-subfilter triangulation options
   "triangulation": {
-    "method": 1,
+    "method": 5,
     "zmin": 0.05,
     "zmax": 5.0
   },

--- a/cfg/phab.json
+++ b/cfg/phab.json
@@ -17,7 +17,7 @@
   "use_OOS": false, // update with Out-Of-State features
   "use_depth_opt": true,  // depth optimization
   "use_MH_gating": true,
-  "use_1pt_RANSAC": false,   
+  "use_1pt_RANSAC": false,
   "use_compression": true,  // measurement compression
   "triangulate_pre_subfilter": true,
   "compression_trigger_ratio": 1.5,
@@ -133,9 +133,11 @@
 
   // pre-subfilter triangulation options
   "triangulation": {
-    "method": "linf_angular",
+    "method": "l1_angular",
     "zmin": 0.05,
-    "zmax": 5.0
+    "zmax": 5.0,
+    "max_theta_thresh": 0.1, // in degrees
+    "beta_thesh": 0.25 // in degrees
   },
 
   "depth_opt": {
@@ -170,7 +172,7 @@
     "model": "equidistant",
     "max_iter": 25,
 
-    "rows": 480, 
+    "rows": 480,
     "cols": 640,
 
     "fx": 274.00289785,
@@ -261,7 +263,7 @@
     },
 
     "GFTT": {
-      // Good Feature To Track 
+      // Good Feature To Track
       // https://docs.opencv.org/3.3.0/df/d21/classcv_1_1GFTTDetector.html
       "maxCorners": 1000,
       "qualityLevel": 0.01,

--- a/cfg/tumvi_cam0.json
+++ b/cfg/tumvi_cam0.json
@@ -15,7 +15,7 @@
   "use_OOS": false, // update with Out-Of-State features
   "use_depth_opt": true,  // depth optimization
   "use_MH_gating": true,
-  "use_1pt_RANSAC": false,   
+  "use_1pt_RANSAC": false,
   "use_compression": false,  // measurement compression
   "triangulate_pre_subfilter": true,
   "compression_trigger_ratio": 1.5,
@@ -131,9 +131,11 @@
 
   // pre-subfilter triangulation options
   "triangulation": {
-    "method": 2,
+    "method": "l1_angular",
     "zmin": 0.05,
-    "zmax": 5.0
+    "zmax": 5.0,
+    "max_theta_thresh": 0.1, // in degrees
+    "beta_thesh": 0.25 // in degrees
   },
 
   "depth_opt": {
@@ -149,23 +151,23 @@
 
   "imu_calib": {
     "Cas": [1, 1, 1],
-    "Car": [[1, 0, 0], 
-            [0, 1, 0], 
+    "Car": [[1, 0, 0],
+            [0, 1, 0],
             [0, 0, 1]],
     "Cgs": [1, 1, 1],
-    "Cgr": [[1, 0, 0], 
-            [0, 1, 0], 
+    "Cgr": [[1, 0, 0],
+            [0, 1, 0],
             [0, 0, 1]]
   },
   "gravity_init_counter": 20,
 
   "camera_cfg": {
     "model": "equidistant",
-    "rows": 512, 
+    "rows": 512,
     "cols": 512,
-    "fx": 190.97847715128717, 
-    "fy": 190.9733070521226, 
-    "cx": 254.93170605935475, 
+    "fx": 190.97847715128717,
+    "fy": 190.9733070521226,
+    "cx": 254.93170605935475,
     "cy": 256.8974428996504,
     "k0123": [0.0034823894022493434, 0.0007150348452162257, -0.0020532361418706202, 0.00020293673591811182],
     "max_iter": 15,
@@ -240,7 +242,7 @@
     },
 
     "GFTT": {
-      // Good Feature To Track 
+      // Good Feature To Track
       // https://docs.opencv.org/3.3.0/df/d21/classcv_1_1GFTTDetector.html
       "maxCorners": 1000,
       "qualityLevel": 0.01,
@@ -270,7 +272,7 @@
     "nn_dist_thresh": 20.0,
     "merge_features": true,
     "feature_merge_cov_factor": 1.0,
-    
+
     "RANSAC": {
       "max_iter": 1000,
       "min_iter": 100,

--- a/cfg/tumvi_cam1.json
+++ b/cfg/tumvi_cam1.json
@@ -16,7 +16,7 @@
   "use_OOS": false, // update with Out-Of-State features
   "use_depth_opt": true,  // depth optimization
   "use_MH_gating": true,
-  "use_1pt_RANSAC": false,   
+  "use_1pt_RANSAC": false,
   "use_compression": true,  // measurement compression
   "triangulate_pre_subfilter": true,
   "compression_trigger_ratio": 1.5,
@@ -133,9 +133,11 @@
 
   // pre-subfilter triangulation options
   "triangulation": {
-    "method": 1,
+    "method": "l1_angular",
     "zmin": 0.05,
-    "zmax": 5.0
+    "zmax": 5.0,
+    "max_theta_thresh": 0.1, // in degrees
+    "beta_thesh": 0.25 // in degrees
   },
 
   "depth_opt": {
@@ -151,24 +153,24 @@
 
   "imu_calib": {
     "Cas": [1, 1, 1],
-    "Car": [[1, 0, 0], 
-            [0, 1, 0], 
+    "Car": [[1, 0, 0],
+            [0, 1, 0],
             [0, 0, 1]],
     "Cgs": [1, 1, 1],
-    "Cgr": [[1, 0, 0], 
-            [0, 1, 0], 
+    "Cgr": [[1, 0, 0],
+            [0, 1, 0],
             [0, 0, 1]]
   },
   "gravity_init_counter": 20,
 
   "camera_cfg": {
     "model": "equidistant",
-    "rows": 512, 
+    "rows": 512,
     "cols": 512,
 
-    "fx": 190.44236969414825, 
-    "fy": 190.4344384721956, 
-    "cx": 252.59949716835982, 
+    "fx": 190.44236969414825,
+    "fy": 190.4344384721956,
+    "cx": 252.59949716835982,
     "cy": 254.91723064636983,
 
     "k0123": [0.0034003170790442797, 0.001766278153469831, -0.00266312569781606, 0.0003299517423931039],
@@ -246,7 +248,7 @@
     },
 
     "GFTT": {
-      // Good Feature To Track 
+      // Good Feature To Track
       // https://docs.opencv.org/3.3.0/df/d21/classcv_1_1GFTTDetector.html
       "maxCorners": 1000,
       "qualityLevel": 0.01,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -164,6 +164,11 @@ add_executable(unitTests_atan
 target_link_libraries(unitTests_atan xest ${deps} gtest gtest_main)
 add_test(NAME CamerasAtan COMMAND unitTests_atan)
 
+add_executable(unitTests_triangulation
+               test/unittest_triangulation.cpp)
+target_link_libraries(unitTests_triangulation xest ${deps} gtest gtest_main)
+add_test(NAME Triangulation COMMAND unitTests_triangulation)
+
 if (BUILD_G2O)
   message(INFO ${libxivo})
   add_executable(test_optimizer test/test_optimizer.cpp)

--- a/src/estimator.cpp
+++ b/src/estimator.cpp
@@ -135,12 +135,12 @@ Estimator::Estimator(const Json::Value &cfg)
 
   triangulate_pre_subfilter_ =
       cfg_.get("triangulate_pre_subfilter", false).asBool();
-  triangulate_options_.method = cfg_["triangulation"].get("method", 1).asString();
+  triangulate_options_.method = cfg_["triangulation"].get("method", "l1_angular").asString();
   triangulate_options_.zmin =
       cfg_["triangulation"].get("zmin", 0.05).asDouble();
   triangulate_options_.zmax = cfg_["triangulation"].get("zmax", 5.0).asDouble();
-  triangulate_options_.max_theta_thresh = cfg_["triangulation"].get("max_theta_thresh", 0.01).asDouble();
-  triangulate_options_.beta_thesh = cfg_["triangulation"].get("beta_thesh", 1e-8).asDouble();
+  triangulate_options_.max_theta_thresh = cfg_["triangulation"].get("max_theta_thresh", 0.1).asDouble() * M_PI / 180;
+  triangulate_options_.beta_thesh = cfg_["triangulation"].get("beta_thesh", 0.25).asDouble() * M_PI / 180;
 
   remove_outlier_counter_ = cfg_.get("remove_outlier_counter", 10).asInt();
 
@@ -184,7 +184,7 @@ Estimator::Estimator(const Json::Value &cfg)
     // For biases obtained by IMU-TK library,
     // the calibrated meaurement is a_calib = K(a_raw + a_bias)
     // whereas in our model a_calib=K * a_raw - a_bias
-    // thus we need convert that. 
+    // thus we need convert that.
     X_.bg = -imu_.Cg() * X_.bg;
     X_.ba = -imu_.Ca() * X_.ba;
   }
@@ -434,7 +434,7 @@ void Estimator::InertialMeasInternal(const timestamp_t &ts, const Vec3 &gyro,
 
       number_t gyro_mag = (abs(gyro(i)) > max_gyro_(i)) ? max_gyro_(i) : abs(gyro(i));
       number_t accel_mag = (abs(accel_wout_grav(i)) > max_accel_(i)) ? max_accel_(i) : abs(accel_wout_grav(i));
-      
+
       gyro_new(i) = sign_gyro * gyro_mag;
       accel_new(i) = sign_accel * accel_mag;
     }
@@ -977,7 +977,7 @@ void Estimator::UpdateJosephForm() {
   // for (int i = 0; i < err_.size(); ++i) {
   //   I_KH_(i, i) += 1;
   // }
-  
+
   // Here, I_KH is actually KH - I, but since
   // update of P is quadratic in I_KH, so it does not matter.
   I_KH_ = K_ * H_;
@@ -1192,7 +1192,7 @@ MatX3 Estimator::InstateFeaturePositions(int n_output) const {
 
   MatX3 feature_positions(npts,3);
 
-  int i = 0; 
+  int i = 0;
   for (auto it = instate_features.begin();
        it != instate_features.end() && i < n_output;
        ) {
@@ -1227,7 +1227,7 @@ MatX3 Estimator::InstateFeatureXc(int n_output) const {
 
   MatX3 feature_positions(npts,3);
 
-  int i = 0; 
+  int i = 0;
   for (auto it = instate_features.begin();
        it != instate_features.end() && i < n_output;
        ) {
@@ -1261,7 +1261,7 @@ MatX6 Estimator::InstateFeatureCovs(int n_output) const {
 
   MatX6 feature_covs(npts,6);
 
-  int i = 0; 
+  int i = 0;
   for (auto it = instate_features.begin();
        it != instate_features.end() && i < n_output;
        ) {
@@ -1304,7 +1304,7 @@ void Estimator::InstateFeaturePositionsAndCovs(int max_output, int &npts,
   feature_last_px.resize(npts,2);
   feature_ids.resize(npts);
 
-  int i = 0; 
+  int i = 0;
   for (auto it = instate_features.begin();
        it != instate_features.end() && i < npts;
        ) {
@@ -1379,7 +1379,7 @@ MatX3 Estimator::InstateFeaturePositions() const
 
   MatX3 feature_positions(num_features,3);
 
-  int i = 0; 
+  int i = 0;
   for (auto it = instate_features_.begin();
        it != instate_features_.end() && i < num_features;
        ) {
@@ -1401,7 +1401,7 @@ MatX3 Estimator::InstateFeatureXc() const
 
   MatX3 feature_positions(num_features,3);
 
-  int i = 0; 
+  int i = 0;
   for (auto it = instate_features_.begin();
        it != instate_features_.end() && i < num_features;
        ) {
@@ -1423,7 +1423,7 @@ MatX6 Estimator::InstateFeatureCovs() const {
 
   MatX6 feature_covs(num_features,6);
 
-  int i = 0; 
+  int i = 0;
   for (auto it = instate_features_.begin();
        it != instate_features_.end() && i < num_features;
        ) {
@@ -1515,7 +1515,7 @@ MatX Estimator::InstateGroupCovs() const
 
   MatX group_covs(num_groups, 21);
 
-  int i = 0; 
+  int i = 0;
   for (auto it = instate_groups_.begin();
        it != instate_groups_.end() && i < num_groups;
        ) {

--- a/src/estimator.cpp
+++ b/src/estimator.cpp
@@ -135,7 +135,7 @@ Estimator::Estimator(const Json::Value &cfg)
 
   triangulate_pre_subfilter_ =
       cfg_.get("triangulate_pre_subfilter", false).asBool();
-  triangulate_options_.method = cfg_["triangulation"].get("method", 1).asInt();
+  triangulate_options_.method = cfg_["triangulation"].get("method", 1).asString();
   triangulate_options_.zmin =
       cfg_["triangulation"].get("zmin", 0.05).asDouble();
   triangulate_options_.zmax = cfg_["triangulation"].get("zmax", 5.0).asDouble();

--- a/src/estimator.cpp
+++ b/src/estimator.cpp
@@ -139,6 +139,8 @@ Estimator::Estimator(const Json::Value &cfg)
   triangulate_options_.zmin =
       cfg_["triangulation"].get("zmin", 0.05).asDouble();
   triangulate_options_.zmax = cfg_["triangulation"].get("zmax", 5.0).asDouble();
+  triangulate_options_.max_theta_thresh = cfg_["triangulation"].get("max_theta_thresh", 0.01).asDouble();
+  triangulate_options_.beta_thesh = cfg_["triangulation"].get("beta_thesh", 1e-8).asDouble();
 
   remove_outlier_counter_ = cfg_.get("remove_outlier_counter", 10).asInt();
 

--- a/src/feature.cpp
+++ b/src/feature.cpp
@@ -700,8 +700,32 @@ void Feature::Triangulate(const SE3 &gsb, const SE3 &gbc,
   Vec2 xc1 = CameraManager::instance()->UnProject(front());
   Vec2 xc2 = CameraManager::instance()->UnProject(back());
   SE3 g12 = (ref_->gsb() * gbc).inv() * (gsb * gbc);
-  Vec3 Xc1 = options.method == 1 ? Triangulate1(g12, xc1, xc2)
-                                 : Triangulate2(g12, xc1, xc2);
+
+  // Vec3 Xc1 = options.method == 3 ? Triangulate1(g12, xc1, xc2)
+  //                                : Triangulate2(g12, xc1, xc2);
+
+  Vec3 Xc1;
+
+  if(options.method == 1)
+  {
+    Xc1 = Triangulate1(g12, xc1, xc2);
+  }
+
+  else if(options.method == 2)
+  {
+    Xc1 = Triangulate2(g12, xc1, xc2);
+  }
+
+  else if(options.method == 3)
+  {
+    Xc1 = Triangulate1(g12, xc1, xc2);
+  }
+
+  else
+  {
+    std::cout << "[ERROR] Incorrect Method for Triangulation:" << options.method << std::endl;
+    exit(1);
+  }
 
   if (auto z = Xc1(2); z < options.zmin || z > options.zmax) {
     // triangulated depth is not great

--- a/src/feature.cpp
+++ b/src/feature.cpp
@@ -716,17 +716,17 @@ void Feature::Triangulate(const SE3 &gsb, const SE3 &gbc,
 
   else if(options.method == "l1_angular")
   {
-    return_output = L1Angular(g12, xc1, xc2, Xc1);
+    return_output = L1Angular(g12, xc1, xc2, Xc1, options.max_theta_thresh, options.beta_thesh);
   }
 
   else if(options.method == "l2_angular")
   {
-    return_output = L2Angular(g12, xc1, xc2, Xc1);
+    return_output = L2Angular(g12, xc1, xc2, Xc1, options.max_theta_thresh, options.beta_thesh);
   }
 
   else if(options.method == "linf_angular")
   {
-    return_output = LinfAngular(g12, xc1, xc2, Xc1);
+    return_output = LinfAngular(g12, xc1, xc2, Xc1, options.max_theta_thresh, options.beta_thesh);
   }
 
   else
@@ -740,18 +740,16 @@ void Feature::Triangulate(const SE3 &gsb, const SE3 &gbc,
     return;
   }
 
-  // Xc1 = {0,0,0};
-
   if (auto z = Xc1(2); z < options.zmin || z > options.zmax) {
     // triangulated depth is not great
     // stick to the constant depth
   } else {
     x_.head<2>() = Xc1.head<2>() / z;
-#ifdef USE_INVDEPTH
-    x_(2) = 1.0 / z;
-#else
-    x_(2) = log(z);
-#endif
+    #ifdef USE_INVDEPTH
+      x_(2) = 1.0 / z;
+    #else
+      x_(2) = log(z);
+    #endif
   }
 
   return;

--- a/src/feature.cpp
+++ b/src/feature.cpp
@@ -703,34 +703,34 @@ void Feature::Triangulate(const SE3 &gsb, const SE3 &gbc,
 
   Vec3 Xc1;
 
-  if(options.method == 1)
+  if(options.method == "l1_reproject")
   {
     Xc1 = Triangulate1(g12, xc1, xc2);
   }
 
-  else if(options.method == 2)
+  else if(options.method == "l2_reproject")
   {
     Xc1 = Triangulate2(g12, xc1, xc2);
   }
 
-  else if(options.method == 3)
+  else if(options.method == "l1_angular")
   {
-    Xc1 = Triangulate3(g12, xc1, xc2);
+    Xc1 = L1Angular(g12, xc1, xc2);
   }
 
-  else if(options.method == 4)
+  else if(options.method == "l2_angular")
   {
-    Xc1 = Triangulate4(g12, xc1, xc2);
+    Xc1 = L2Angular(g12, xc1, xc2);
   }
 
-  else if(options.method == 5)
+  else if(options.method == "linf_angular")
   {
-    Xc1 = Triangulate5(g12, xc1, xc2);
+    Xc1 = LinfAngular(g12, xc1, xc2);
   }
 
   else
   {
-    std::cout << "[ERROR] Incorrect Method for Triangulation:" << options.method << std::endl;
+    LOG(ERROR) << "[ERROR] Incorrect Method for Triangulation: " << options.method;
     exit(1);
   }
 

--- a/src/feature.cpp
+++ b/src/feature.cpp
@@ -701,32 +701,32 @@ void Feature::Triangulate(const SE3 &gsb, const SE3 &gbc,
   Vec2 xc2 = CameraManager::instance()->UnProject(back());
   SE3 g12 = (ref_->gsb() * gbc).inv() * (gsb * gbc);
 
-  Vec3 Xc1;
+  Vec3 Xc2;
   bool return_output;
 
   if(options.method == "direct_linear_transform_svd")
   {
-    return_output = DirectLinearTransformSVD(g12, xc1, xc2, Xc1);
+    return_output = DirectLinearTransformSVD(g12, xc1, xc2, Xc2);
   }
 
   else if(options.method == "direct_linear_transform_avg")
   {
-    return_output = DirectLinearTransformAvg(g12, xc1, xc2, Xc1);
+    return_output = DirectLinearTransformAvg(g12, xc1, xc2, Xc2);
   }
 
   else if(options.method == "l1_angular")
   {
-    return_output = L1Angular(g12, xc1, xc2, Xc1, options.max_theta_thresh, options.beta_thesh);
+    return_output = L1Angular(g12, xc1, xc2, Xc2, options.max_theta_thresh, options.beta_thesh);
   }
 
   else if(options.method == "l2_angular")
   {
-    return_output = L2Angular(g12, xc1, xc2, Xc1, options.max_theta_thresh, options.beta_thesh);
+    return_output = L2Angular(g12, xc1, xc2, Xc2, options.max_theta_thresh, options.beta_thesh);
   }
 
   else if(options.method == "linf_angular")
   {
-    return_output = LinfAngular(g12, xc1, xc2, Xc1, options.max_theta_thresh, options.beta_thesh);
+    return_output = LinfAngular(g12, xc1, xc2, Xc2, options.max_theta_thresh, options.beta_thesh);
   }
 
   else
@@ -740,11 +740,11 @@ void Feature::Triangulate(const SE3 &gsb, const SE3 &gbc,
     return;
   }
 
-  if (auto z = Xc1(2); z < options.zmin || z > options.zmax) {
+  if (auto z = Xc2(2); z < options.zmin || z > options.zmax) {
     // triangulated depth is not great
     // stick to the constant depth
   } else {
-    x_.head<2>() = Xc1.head<2>() / z;
+    x_.head<2>() = Xc2.head<2>() / z;
     #ifdef USE_INVDEPTH
       x_(2) = 1.0 / z;
     #else

--- a/src/feature.cpp
+++ b/src/feature.cpp
@@ -703,16 +703,14 @@ void Feature::Triangulate(const SE3 &gsb, const SE3 &gbc,
 
   Vec3 Xc1;
 
-  // std::cout << options.max_theta_thresh << " " << options.beta_thesh << std::endl;
-
-  if(options.method == "l1_reproject")
+  if(options.method == "direct_linear_transform_svd")
   {
-    Xc1 = Triangulate1(g12, xc1, xc2);
+    Xc1 = DirectLinearTransformSVD(g12, xc1, xc2);
   }
 
-  else if(options.method == "l2_reproject")
+  else if(options.method == "direct_linear_transform_avg")
   {
-    Xc1 = Triangulate2(g12, xc1, xc2);
+    Xc1 = DirectLinearTransformAvg(g12, xc1, xc2);
   }
 
   else if(options.method == "l1_angular")

--- a/src/feature.cpp
+++ b/src/feature.cpp
@@ -703,6 +703,8 @@ void Feature::Triangulate(const SE3 &gsb, const SE3 &gbc,
 
   Vec3 Xc1;
 
+  // std::cout << options.max_theta_thresh << " " << options.beta_thesh << std::endl;
+
   if(options.method == "l1_reproject")
   {
     Xc1 = Triangulate1(g12, xc1, xc2);

--- a/src/feature.cpp
+++ b/src/feature.cpp
@@ -701,32 +701,32 @@ void Feature::Triangulate(const SE3 &gsb, const SE3 &gbc,
   Vec2 xc2 = CameraManager::instance()->UnProject(back());
   SE3 g12 = (ref_->gsb() * gbc).inv() * (gsb * gbc);
 
-  Vec3 Xc2;
+  Vec3 Xc1;
   bool return_output;
 
   if(options.method == "direct_linear_transform_svd")
   {
-    return_output = DirectLinearTransformSVD(g12, xc1, xc2, Xc2);
+    return_output = DirectLinearTransformSVD(g12, xc1, xc2, Xc1);
   }
 
   else if(options.method == "direct_linear_transform_avg")
   {
-    return_output = DirectLinearTransformAvg(g12, xc1, xc2, Xc2);
+    return_output = DirectLinearTransformAvg(g12, xc1, xc2, Xc1);
   }
 
   else if(options.method == "l1_angular")
   {
-    return_output = L1Angular(g12, xc1, xc2, Xc2, options.max_theta_thresh, options.beta_thesh);
+    return_output = L1Angular(g12, xc1, xc2, Xc1, options.max_theta_thresh, options.beta_thesh);
   }
 
   else if(options.method == "l2_angular")
   {
-    return_output = L2Angular(g12, xc1, xc2, Xc2, options.max_theta_thresh, options.beta_thesh);
+    return_output = L2Angular(g12, xc1, xc2, Xc1, options.max_theta_thresh, options.beta_thesh);
   }
 
   else if(options.method == "linf_angular")
   {
-    return_output = LinfAngular(g12, xc1, xc2, Xc2, options.max_theta_thresh, options.beta_thesh);
+    return_output = LinfAngular(g12, xc1, xc2, Xc1, options.max_theta_thresh, options.beta_thesh);
   }
 
   else
@@ -740,11 +740,11 @@ void Feature::Triangulate(const SE3 &gsb, const SE3 &gbc,
     return;
   }
 
-  if (auto z = Xc2(2); z < options.zmin || z > options.zmax) {
+  if (auto z = Xc1(2); z < options.zmin || z > options.zmax) {
     // triangulated depth is not great
     // stick to the constant depth
   } else {
-    x_.head<2>() = Xc2.head<2>() / z;
+    x_.head<2>() = Xc1.head<2>() / z;
     #ifdef USE_INVDEPTH
       x_(2) = 1.0 / z;
     #else

--- a/src/feature.cpp
+++ b/src/feature.cpp
@@ -701,9 +701,6 @@ void Feature::Triangulate(const SE3 &gsb, const SE3 &gbc,
   Vec2 xc2 = CameraManager::instance()->UnProject(back());
   SE3 g12 = (ref_->gsb() * gbc).inv() * (gsb * gbc);
 
-  // Vec3 Xc1 = options.method == 3 ? Triangulate1(g12, xc1, xc2)
-  //                                : Triangulate2(g12, xc1, xc2);
-
   Vec3 Xc1;
 
   if(options.method == 1)
@@ -718,7 +715,12 @@ void Feature::Triangulate(const SE3 &gsb, const SE3 &gbc,
 
   else if(options.method == 3)
   {
-    Xc1 = Triangulate1(g12, xc1, xc2);
+    Xc1 = Triangulate3(g12, xc1, xc2);
+  }
+
+  else if(options.method == 4)
+  {
+    Xc1 = Triangulate4(g12, xc1, xc2);
   }
 
   else

--- a/src/feature.cpp
+++ b/src/feature.cpp
@@ -723,6 +723,11 @@ void Feature::Triangulate(const SE3 &gsb, const SE3 &gbc,
     Xc1 = Triangulate4(g12, xc1, xc2);
   }
 
+  else if(options.method == 5)
+  {
+    Xc1 = Triangulate5(g12, xc1, xc2);
+  }
+
   else
   {
     std::cout << "[ERROR] Incorrect Method for Triangulation:" << options.method << std::endl;

--- a/src/feature.h
+++ b/src/feature.h
@@ -223,7 +223,7 @@ public:
    *  overlap.
    *  \todo Completely separate feature and group IDs so that we don't have
    *        problems if this SLAM code is ever run for a long, long time.  */
-  static constexpr int counter0 = 10000;  
+  static constexpr int counter0 = 10000;
 
 private:
   Feature(const Feature &) = delete;

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -243,4 +243,39 @@ Vec3 Triangulate4(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2) {
   return x;
 }
 
+Vec3 Triangulate5(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2) {
+
+  // Initalize the Rotation and Translation Matricies
+  Vec3 t12{g12.T()};
+  Mat3 R12{g12.R()};
+  Mat3 R21{R12.transpose()};
+  Vec3 t21{-1 * R12.transpose() * t12};
+
+  // Create homogeneous coordinates
+  Vec3 f0{xc1(0), xc1(1), 1.0};
+  f0.normalize(); // WHY?
+  Vec3 f1{xc2(0), xc2(1), 1.0};
+  f1.normalize();  
+
+  Vec3 m0{R21 * f0};
+  Vec3 m1{f1};
+
+  Vec3 m0_hat = m0 / m0.norm();
+  Vec3 m1_hat = m1 / m1.norm();
+
+  Vec3 n_a = (m0_hat + m1_hat).cross(t21);
+  Vec3 n_b = (m0_hat - m1_hat).cross(t21);
+
+  Vec3 n_prime_hat = n_a.norm() >= n_b.norm() ? n_a : n_b;
+
+  Vec3 m0_prime = m0 - m0.dot(n_prime_hat) * n_prime_hat;
+  Vec3 m1_prime = m1 - m1.dot(n_prime_hat) * n_prime_hat;
+
+  Vec3 z = m1_prime.cross(m0_prime);
+
+  Vec3 x = ((z.dot(t21.cross(m0_prime))) / pow(z.norm(),2)) * m1_prime;
+
+  return x;
+}
+
 } // namespace xivo

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -162,7 +162,7 @@ Vec3 Triangulate3(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2) {
 
   // Create homogeneous coordinates
   Vec3 f0{xc1(0), xc1(1), 1.0};
-  f0.normalize(); // WHY?
+  f0.normalize();
   Vec3 f1{xc2(0), xc2(1), 1.0};
   f1.normalize();  
 
@@ -208,7 +208,7 @@ Vec3 Triangulate4(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2) {
 
   // Create homogeneous coordinates
   Vec3 f0{xc1(0), xc1(1), 1.0};
-  f0.normalize(); // WHY?
+  f0.normalize();
   Vec3 f1{xc2(0), xc2(1), 1.0};
   f1.normalize();  
 
@@ -253,7 +253,7 @@ Vec3 Triangulate5(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2) {
 
   // Create homogeneous coordinates
   Vec3 f0{xc1(0), xc1(1), 1.0};
-  f0.normalize(); // WHY?
+  f0.normalize();
   Vec3 f1{xc2(0), xc2(1), 1.0};
   f1.normalize();  
 
@@ -273,9 +273,60 @@ Vec3 Triangulate5(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2) {
 
   Vec3 z = m1_prime.cross(m0_prime);
 
-  Vec3 x = ((z.dot(t21.cross(m0_prime))) / pow(z.norm(),2)) * m1_prime;
+  // check_cheirality(z, t21, m1_prime, m0_prime);
+  // check_angular_reprojection(m0, m0_prime, m1, m1_prime);
+  // check_parallax(m0_prime, m1_prime);
+
+  Vec3 x = ((z.dot(t21.cross(m0_prime))) / pow(z.norm(), 2)) * m1_prime;
 
   return x;
+}
+
+
+void check_cheirality(const Vec3 &z, const Vec3 &t, const Vec3 &f1_prime, const Vec3 &Rf0_prime)
+{
+
+  float lambda0 = z.dot(t.cross(f1_prime)) / pow(z.norm(), 2);
+  float lambda1 = z.dot(t.cross(Rf0_prime)) / pow(z.norm(), 2);
+
+  if(lambda0 <= 0 || lambda1 <= 0)
+  {
+    std::cout << "[ERROR] cheirality error in triangulation. lambda0=" << lambda0 << ", lamba1=" << lambda1 << std::endl;
+    exit(1);
+  }
+
+  return;
+}
+
+
+void check_angular_reprojection(const Vec3 &Rf0, const Vec3 &Rf0_prime, const Vec3 &f1, const Vec3 &f1_prime)
+{
+
+  float theta0 = acos(Rf0.dot(Rf0_prime) / (Rf0.norm() * Rf0_prime.norm()));
+  float theta1 = acos(f1.dot(f1_prime) / (f1.norm() * f1_prime.norm()));
+
+  float max_theta = std::max(theta0, theta1);
+
+  if(max_theta > 0.01)
+  {
+    std::cout << "[ERROR] angular reprojection error in triangulation" << std::endl;
+    exit(1);
+  }
+  return;
+}
+
+void check_parallax(const Vec3 &Rf0_prime, const Vec3 &f1_prime)
+{
+
+  float beta = acos(f1_prime.dot(Rf0_prime) / (f1_prime.norm() * Rf0_prime.norm()));
+
+  if(beta < 1e-8)
+  {
+    std::cout << "[ERROR] parallax error in triangulation " << beta <<  std::endl;
+    exit(1);
+  }
+
+  return;
 }
 
 } // namespace xivo

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -151,4 +151,96 @@ Vec3 Triangulate2(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2) {
   return x;
 }
 
+
+Vec3 Triangulate3(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2) {
+
+  // Initalize the Rotation and Translation Matricies
+  Vec3 t12{g12.T()};
+  Mat3 R12{g12.R()};
+  Mat3 R21{R12.transpose()};
+  Vec3 t21{-1 * R12.transpose() * t12};
+
+  // Create homogeneous coordinates
+  Vec3 f0{xc1(0), xc1(1), 1.0};
+  f0.normalize(); // WHY?
+  Vec3 f1{xc2(0), xc2(1), 1.0};
+  f1.normalize();  
+
+  Vec3 m0{R21 * f0};
+  Vec3 m1{f1};
+
+  float a0 = ((m0 / m0.norm()).cross(t21)).norm();
+  float a1 = ((m1 / m1.norm()).cross(t21)).norm();
+
+  Vec3 m0_prime;
+  Vec3 m1_prime;
+
+  if(a0 <= a1)
+  {
+    Vec3 n1 = m1.cross(t21);
+    Vec3 n1_hat = n1 / n1.norm();
+    m0_prime = m0 - (m0.dot(n1_hat)) * n1_hat;
+    m1_prime = m1;
+  }
+  else
+  {
+    Vec3 n0 = m0.cross(t21);
+    Vec3 n0_hat = n0 / n0.norm();
+    m0_prime = m0;
+    m1_prime = m1 - (m1.dot(n0_hat)) * n0_hat;
+  }
+
+  Vec3 z = m1_prime.cross(m0_prime);
+
+  Vec3 x = ((z.dot(t21.cross(m0_prime))) / pow(z.norm(),2)) * m1_prime;
+
+  return x;
+}
+
+
+Vec3 Triangulate4(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2) {
+
+  // Initalize the Rotation and Translation Matricies
+  Vec3 t12{g12.T()};
+  Mat3 R12{g12.R()};
+  Mat3 R21{R12.transpose()};
+  Vec3 t21{-1 * R12.transpose() * t12};
+
+  // Create homogeneous coordinates
+  Vec3 f0{xc1(0), xc1(1), 1.0};
+  f0.normalize(); // WHY?
+  Vec3 f1{xc2(0), xc2(1), 1.0};
+  f1.normalize();  
+
+  Vec3 m0{R21 * f0};
+  Vec3 m1{f1};
+
+  float a0 = ((m0 / m0.norm()).cross(t21)).norm();
+  float a1 = ((m1 / m1.norm()).cross(t21)).norm();
+
+  Vec3 m0_prime;
+  Vec3 m1_prime;
+
+  if(a0 <= a1)
+  {
+    Vec3 n1 = m1.cross(t21);
+    Vec3 n1_hat = n1 / n1.norm();
+    m0_prime = m0 - (m0.dot(n1_hat)) * n1_hat;
+    m1_prime = m1;
+  }
+  else
+  {
+    Vec3 n0 = m0.cross(t21);
+    Vec3 n0_hat = n0 / n0.norm();
+    m0_prime = m0;
+    m1_prime = m1 - (m1.dot(n0_hat)) * n0_hat;
+  }
+
+  Vec3 z = m1_prime.cross(m0_prime);
+
+  Vec3 x = ((z.dot(t21.cross(m0_prime))) / pow(z.norm(),2)) * m1_prime;
+
+  return x;
+}
+
 } // namespace xivo

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -190,9 +190,12 @@ Vec3 L1Angular(const SE3 &g12, const Vec2 &xc0, const Vec2 &xc1) {
     m1_prime = m1 - (m1.dot(n0_hat)) * n0_hat;
   }
 
-  Vec3 z = m1_prime.cross(m0_prime);
+  Vec3 Rf0_prime = m0_prime;
+  Vec3 f1_prime = m1_prime;
 
-  Vec3 x = ((z.dot(t21.cross(m0_prime))) / pow(z.norm(),2)) * m1_prime;
+  Vec3 z = f1_prime.cross(Rf0_prime);
+
+  Vec3 x = ((z.dot(t21.cross(Rf0_prime))) / pow(z.norm(),2)) * f1_prime;
 
   return x;
 }
@@ -236,11 +239,12 @@ Vec3 L2Angular(const SE3 &g12, const Vec2 &xc0, const Vec2 &xc1) {
   Vec3 m0_prime = m0 - m0.dot(n_prime_hat) * n_prime_hat;
   Vec3 m1_prime = m1 - m1.dot(n_prime_hat) * n_prime_hat;
 
-  Vec3 z = m1_prime.cross(m0_prime);
+  Vec3 Rf0_prime = m0_prime;
+  Vec3 f1_prime = m1_prime;
 
-  Vec3 x = ((z.dot(t21.cross(m0_prime))) / pow(z.norm(),2)) * m1_prime;
+  Vec3 z = f1_prime.cross(Rf0_prime);
 
-  // Vec3 x1 = R12 * x + t12;
+  Vec3 x = ((z.dot(t21.cross(Rf0_prime))) / pow(z.norm(),2)) * f1_prime;
 
   return x;
 }
@@ -273,15 +277,16 @@ Vec3 LinfAngular(const SE3 &g12, const Vec2 &xc0, const Vec2 &xc1) {
   Vec3 m0_prime = m0 - m0.dot(n_prime_hat) * n_prime_hat;
   Vec3 m1_prime = m1 - m1.dot(n_prime_hat) * n_prime_hat;
 
-  Vec3 z = m1_prime.cross(m0_prime);
+  Vec3 Rf0_prime = m0_prime;
+  Vec3 f1_prime = m1_prime;
 
-  check_cheirality(z, t21, m1_prime, m0_prime);
-  check_angular_reprojection(m0, m0_prime, m1, m1_prime);
-  check_parallax(m0_prime, m1_prime);
+  Vec3 z = f1_prime.cross(Rf0_prime);
 
-  Vec3 x = ((z.dot(t21.cross(m0_prime))) / pow(z.norm(), 2)) * m1_prime;
+  // check_cheirality(z, t21, m1_prime, m0_prime);
+  // check_angular_reprojection(m0, m0_prime, m1, m1_prime);
+  // check_parallax(m0_prime, m1_prime);
 
-  // Vec3 x1 = R12 * x + t12;
+  Vec3 x = ((z.dot(t21.cross(Rf0_prime))) / pow(z.norm(),2)) * f1_prime;
 
   return x;
 }

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -121,15 +121,10 @@ bool DirectLinearTransformSVD(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2, 
 
   Eigen::JacobiSVD<Mat4> svd(A, Eigen::ComputeFullV);
   auto V = svd.matrixV();
-  Vec3 X1;
-  X1 << V(0, 3), V(1, 3), V(2, 3);
-  X1 /= V(3, 3);
 
-  Mat3 R21{R12.transpose()};
-  Vec3 t21{-1 * R12.transpose() * t12};
+  X << V(0, 3), V(1, 3), V(2, 3);
+  X /= V(3, 3);
 
-  // Returns point from 2nd frame of reference
-  X = R21 * X1 + t21;
   return true;
 }
 
@@ -153,13 +148,8 @@ bool DirectLinearTransformAvg(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2, 
   Vec2 lambda = A.inverse() * b;
   Vec3 xm = lambda(0) * f1;
   Vec3 xn = t12 + lambda(1) * f2_unrotated;
-  Vec3 X1 = (xm + xn) / 2.0; // in frame 1
+  X = (xm + xn) / 2.0; // in frame 1
 
-  Mat3 R21{R12.transpose()};
-  Vec3 t21{-1 * R12.transpose() * t12};
-
-  // Returns point from 2nd frame of reference
-  X = R21 * X1 + t21;
   return true;
 }
 

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -152,7 +152,7 @@ Vec3 Triangulate2(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2) {
 }
 
 
-Vec3 Triangulate3(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2) {
+Vec3 L1Angular(const SE3 &g12, const Vec2 &xc0, const Vec2 &xc1) {
 
   // Initalize the Rotation and Translation Matricies
   Vec3 t12{g12.T()};
@@ -161,9 +161,9 @@ Vec3 Triangulate3(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2) {
   Vec3 t21{-1 * R12.transpose() * t12};
 
   // Create homogeneous coordinates
-  Vec3 f0{xc1(0), xc1(1), 1.0};
+  Vec3 f0{xc0(0), xc0(1), 1.0};
   f0.normalize();
-  Vec3 f1{xc2(0), xc2(1), 1.0};
+  Vec3 f1{xc1(0), xc1(1), 1.0};
   f1.normalize();  
 
   Vec3 m0{R21 * f0};
@@ -198,7 +198,7 @@ Vec3 Triangulate3(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2) {
 }
 
 
-Vec3 Triangulate4(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2) {
+Vec3 L2Angular(const SE3 &g12, const Vec2 &xc0, const Vec2 &xc1) {
 
   // Initalize the Rotation and Translation Matricies
   Vec3 t12{g12.T()};
@@ -207,9 +207,9 @@ Vec3 Triangulate4(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2) {
   Vec3 t21{-1 * R12.transpose() * t12};
 
   // Create homogeneous coordinates
-  Vec3 f0{xc1(0), xc1(1), 1.0};
+  Vec3 f0{xc0(0), xc0(1), 1.0};
   f0.normalize();
-  Vec3 f1{xc2(0), xc2(1), 1.0};
+  Vec3 f1{xc1(0), xc1(1), 1.0};
   f1.normalize();  
 
   Vec3 m0{R21 * f0};
@@ -240,10 +240,12 @@ Vec3 Triangulate4(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2) {
 
   Vec3 x = ((z.dot(t21.cross(m0_prime))) / pow(z.norm(),2)) * m1_prime;
 
+  // Vec3 x1 = R12 * x + t12;
+
   return x;
 }
 
-Vec3 Triangulate5(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2) {
+Vec3 LinfAngular(const SE3 &g12, const Vec2 &xc0, const Vec2 &xc1) {
 
   // Initalize the Rotation and Translation Matricies
   Vec3 t12{g12.T()};
@@ -252,9 +254,9 @@ Vec3 Triangulate5(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2) {
   Vec3 t21{-1 * R12.transpose() * t12};
 
   // Create homogeneous coordinates
-  Vec3 f0{xc1(0), xc1(1), 1.0};
+  Vec3 f0{xc0(0), xc0(1), 1.0};
   f0.normalize();
-  Vec3 f1{xc2(0), xc2(1), 1.0};
+  Vec3 f1{xc1(0), xc1(1), 1.0};
   f1.normalize();  
 
   Vec3 m0{R21 * f0};
@@ -273,11 +275,13 @@ Vec3 Triangulate5(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2) {
 
   Vec3 z = m1_prime.cross(m0_prime);
 
-  // check_cheirality(z, t21, m1_prime, m0_prime);
-  // check_angular_reprojection(m0, m0_prime, m1, m1_prime);
-  // check_parallax(m0_prime, m1_prime);
+  check_cheirality(z, t21, m1_prime, m0_prime);
+  check_angular_reprojection(m0, m0_prime, m1, m1_prime);
+  check_parallax(m0_prime, m1_prime);
 
   Vec3 x = ((z.dot(t21.cross(m0_prime))) / pow(z.norm(), 2)) * m1_prime;
+
+  // Vec3 x1 = R12 * x + t12;
 
   return x;
 }
@@ -291,7 +295,7 @@ void check_cheirality(const Vec3 &z, const Vec3 &t, const Vec3 &f1_prime, const 
 
   if(lambda0 <= 0 || lambda1 <= 0)
   {
-    std::cout << "[ERROR] cheirality error in triangulation. lambda0=" << lambda0 << ", lamba1=" << lambda1 << std::endl;
+    LOG(ERROR) << "[ERROR] cheirality error in triangulation. lambda0=" << lambda0 << ", lamba1=" << lambda1;
     exit(1);
   }
 
@@ -309,7 +313,7 @@ void check_angular_reprojection(const Vec3 &Rf0, const Vec3 &Rf0_prime, const Ve
 
   if(max_theta > 0.01)
   {
-    std::cout << "[ERROR] angular reprojection error in triangulation" << std::endl;
+    LOG(ERROR) << "[ERROR] angular reprojection error in triangulation";
     exit(1);
   }
   return;
@@ -322,7 +326,7 @@ void check_parallax(const Vec3 &Rf0_prime, const Vec3 &f1_prime)
 
   if(beta < 1e-8)
   {
-    std::cout << "[ERROR] parallax error in triangulation " << beta <<  std::endl;
+    LOG(ERROR) << "[ERROR] parallax error in triangulation " << beta;
     exit(1);
   }
 

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -148,7 +148,7 @@ bool DirectLinearTransformAvg(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2, 
   Vec2 lambda = A.inverse() * b;
   Vec3 xm = lambda(0) * f1;
   Vec3 xn = t12 + lambda(1) * f2_unrotated;
-  X = (xm + xn) / 2.0; // in frame 1
+  X = (xm + xn) / 2.0;
 
   return true;
 }
@@ -197,8 +197,11 @@ bool L1Angular(const SE3 &g01, const Vec2 &xc0, const Vec2 &xc1, Vec3 &X, float 
 
   Vec3 z = f1_prime.cross(Rf0_prime);
 
-  // Returns point from 2nd frame of reference
+
   X = ((z.dot(t10.cross(Rf0_prime))) / pow(z.norm(),2)) * f1_prime;
+
+  // Returns point from 1st frame of reference
+  X = R01 * X + t01;
 
   // Check the conditions
   if(!check_cheirality(z, t10, f1_prime, Rf0_prime) ||
@@ -255,8 +258,10 @@ bool L2Angular(const SE3 &g01, const Vec2 &xc0, const Vec2 &xc1, Vec3 &X, float 
 
   Vec3 z = f1_prime.cross(Rf0_prime);
 
-  // Returns point from 2nd frame of reference
   X = ((z.dot(t10.cross(Rf0_prime))) / pow(z.norm(),2)) * f1_prime;
+
+  // Returns point from 1st frame of reference
+  X = R01 * X + t01;
 
   // Check the conditions
   if(!check_cheirality(z, t10, f1_prime, Rf0_prime) ||
@@ -302,8 +307,10 @@ bool LinfAngular(const SE3 &g01, const Vec2 &xc0, const Vec2 &xc1, Vec3 &X, floa
 
   Vec3 z = f1_prime.cross(Rf0_prime);
 
-  // Returns point from 2nd frame of reference
   X = ((z.dot(t10.cross(Rf0_prime))) / pow(z.norm(),2)) * f1_prime;
+
+  // Returns point from 1st frame of reference
+  X = R01 * X + t01;
 
   // Check the conditions
   if(!check_cheirality(z, t10, f1_prime, Rf0_prime) ||

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -48,4 +48,14 @@ Vec3 Triangulate1(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2);
 // interface same as triangulation method1 above
 Vec3 Triangulate2(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2);
 
+// triangulation method3
+// Based on Angular Errors - https://arxiv.org/abs/1903.09115
+// L1 triangulation
+Vec3 Triangulate3(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2);
+
+// triangulation method3
+// Based on Angular Errors - https://arxiv.org/abs/1903.09115
+// L2 triangulation
+Vec3 Triangulate4(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2);
+
 } // namespace xivo

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -51,25 +51,25 @@ bool DirectLinearTransformAvg(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2, 
 // triangulation method3
 // Based on Angular Errors - https://arxiv.org/abs/1903.09115
 // L1 triangulation
-bool L1Angular(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2, Vec3 &x);
+bool L1Angular(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2, Vec3 &X, float max_theta_thresh, float beta_thresh);
 
 // triangulation method4
 // Based on Angular Errors - https://arxiv.org/abs/1903.09115
 // L2 triangulation
-bool L2Angular(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2, Vec3 &x);
+bool L2Angular(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2, Vec3 &X, float max_theta_thresh, float beta_thresh);
 
 // triangulation method5
 // Based on Angular Errors - https://arxiv.org/abs/1903.09115
 // L_inf triangulation
-bool LinfAngular(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2, Vec3 &x);
+bool LinfAngular(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2, Vec3 &X, float max_theta_thresh, float beta_thresh);
 
 // Check cheirality error for above methods
 bool check_cheirality(const Vec3 &z, const Vec3 &t, const Vec3 &f1_prime, const Vec3 &Rf0_prime);
 
 // Check angular reprojection error for above methods
-bool check_angular_reprojection(const Vec3 &f0, const Vec3 &f0_prime, const Vec3 &f1, const Vec3 &f1_prime);
+bool check_angular_reprojection(const Vec3 &Rf0, const Vec3 &Rf0_prime, const Vec3 &f1, const Vec3 &f1_prime, float max_theta_thresh);
 
 // Check parallex error for above methods
-bool check_parallax(const Vec3 &Rf0_prime, const Vec3 &f1_prime);
+bool check_parallax(const Vec3 &Rf0_prime, const Vec3 &f1_prime, float beta_thesh);
 
 } // namespace xivo

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -33,7 +33,7 @@ static Mat2 givens(number_t a, number_t b);
 // Returns: size of the upper triangular matrix Th
 int QR(VecX &r, MatX &Hx, int effective_rows = -1);
 
-template <typename T> bool MakePtrVectorUnique(std::vector<T *> &v) {
+template <typename T> void MakePtrVectorUnique(std::vector<T *> &v) {
   std::sort(v.begin(), v.end());
   v.erase(std::unique(v.begin(), v.end()), v.end());
 }

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -42,11 +42,11 @@ template <typename T> void MakePtrVectorUnique(std::vector<T *> &v) {
 // g12: 2->1
 // xc1: camera coordinates in frame 1
 // xc2: camera coordiantes in frame 2
-Vec3 Triangulate1(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2);
+Vec3 DirectLinearTransformSVD(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2);
 
 // triangulation method2
 // interface same as triangulation method1 above
-Vec3 Triangulate2(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2);
+Vec3 DirectLinearTransformAvg(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2);
 
 // triangulation method3
 // Based on Angular Errors - https://arxiv.org/abs/1903.09115

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -33,7 +33,7 @@ static Mat2 givens(number_t a, number_t b);
 // Returns: size of the upper triangular matrix Th
 int QR(VecX &r, MatX &Hx, int effective_rows = -1);
 
-template <typename T> void MakePtrVectorUnique(std::vector<T *> &v) {
+template <typename T> bool MakePtrVectorUnique(std::vector<T *> &v) {
   std::sort(v.begin(), v.end());
   v.erase(std::unique(v.begin(), v.end()), v.end());
 }
@@ -42,34 +42,34 @@ template <typename T> void MakePtrVectorUnique(std::vector<T *> &v) {
 // g12: 2->1
 // xc1: camera coordinates in frame 1
 // xc2: camera coordiantes in frame 2
-Vec3 DirectLinearTransformSVD(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2);
+bool DirectLinearTransformSVD(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2, Vec3 &x);
 
 // triangulation method2
 // interface same as triangulation method1 above
-Vec3 DirectLinearTransformAvg(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2);
+bool DirectLinearTransformAvg(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2, Vec3 &x);
 
 // triangulation method3
 // Based on Angular Errors - https://arxiv.org/abs/1903.09115
 // L1 triangulation
-Vec3 L1Angular(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2);
+bool L1Angular(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2, Vec3 &x);
 
 // triangulation method4
 // Based on Angular Errors - https://arxiv.org/abs/1903.09115
 // L2 triangulation
-Vec3 L2Angular(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2);
+bool L2Angular(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2, Vec3 &x);
 
 // triangulation method5
 // Based on Angular Errors - https://arxiv.org/abs/1903.09115
 // L_inf triangulation
-Vec3 LinfAngular(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2);
+bool LinfAngular(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2, Vec3 &x);
 
 // Check cheirality error for above methods
-void check_cheirality(const Vec3 &z, const Vec3 &t, const Vec3 &f1_prime, const Vec3 &Rf0_prime);
+bool check_cheirality(const Vec3 &z, const Vec3 &t, const Vec3 &f1_prime, const Vec3 &Rf0_prime);
 
 // Check angular reprojection error for above methods
-void check_angular_reprojection(const Vec3 &f0, const Vec3 &f0_prime, const Vec3 &f1, const Vec3 &f1_prime);
+bool check_angular_reprojection(const Vec3 &f0, const Vec3 &f0_prime, const Vec3 &f1, const Vec3 &f1_prime);
 
 // Check parallex error for above methods
-void check_parallax(const Vec3 &Rf0_prime, const Vec3 &f1_prime);
+bool check_parallax(const Vec3 &Rf0_prime, const Vec3 &f1_prime);
 
 } // namespace xivo

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -51,17 +51,17 @@ bool DirectLinearTransformAvg(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2, 
 // triangulation method3
 // Based on Angular Errors - https://arxiv.org/abs/1903.09115
 // L1 triangulation
-bool L1Angular(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2, Vec3 &X, float max_theta_thresh, float beta_thresh);
+bool L1Angular(const SE3 &g01, const Vec2 &xc1, const Vec2 &xc2, Vec3 &X, float max_theta_thresh, float beta_thresh);
 
 // triangulation method4
 // Based on Angular Errors - https://arxiv.org/abs/1903.09115
 // L2 triangulation
-bool L2Angular(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2, Vec3 &X, float max_theta_thresh, float beta_thresh);
+bool L2Angular(const SE3 &g01, const Vec2 &xc1, const Vec2 &xc2, Vec3 &X, float max_theta_thresh, float beta_thresh);
 
 // triangulation method5
 // Based on Angular Errors - https://arxiv.org/abs/1903.09115
 // L_inf triangulation
-bool LinfAngular(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2, Vec3 &X, float max_theta_thresh, float beta_thresh);
+bool LinfAngular(const SE3 &g01, const Vec2 &xc1, const Vec2 &xc2, Vec3 &X, float max_theta_thresh, float beta_thresh);
 
 // Check cheirality error for above methods
 bool check_cheirality(const Vec3 &z, const Vec3 &t, const Vec3 &f1_prime, const Vec3 &Rf0_prime);

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -63,4 +63,13 @@ Vec3 Triangulate4(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2);
 // L_inf triangulation
 Vec3 Triangulate5(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2);
 
+// Check cheirality error for above methods
+void check_cheirality(const Vec3 &z, const Vec3 &t, const Vec3 &f1_prime, const Vec3 &Rf0_prime);
+
+// Check angular reprojection error for above methods
+void check_angular_reprojection(const Vec3 &f0, const Vec3 &f0_prime, const Vec3 &f1, const Vec3 &f1_prime);
+
+// Check parallex error for above methods
+void check_parallax(const Vec3 &Rf0_prime, const Vec3 &f1_prime);
+
 } // namespace xivo

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -53,9 +53,14 @@ Vec3 Triangulate2(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2);
 // L1 triangulation
 Vec3 Triangulate3(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2);
 
-// triangulation method3
+// triangulation method4
 // Based on Angular Errors - https://arxiv.org/abs/1903.09115
 // L2 triangulation
 Vec3 Triangulate4(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2);
+
+// triangulation method5
+// Based on Angular Errors - https://arxiv.org/abs/1903.09115
+// L_inf triangulation
+Vec3 Triangulate5(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2);
 
 } // namespace xivo

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -51,17 +51,17 @@ Vec3 Triangulate2(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2);
 // triangulation method3
 // Based on Angular Errors - https://arxiv.org/abs/1903.09115
 // L1 triangulation
-Vec3 Triangulate3(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2);
+Vec3 L1Angular(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2);
 
 // triangulation method4
 // Based on Angular Errors - https://arxiv.org/abs/1903.09115
 // L2 triangulation
-Vec3 Triangulate4(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2);
+Vec3 L2Angular(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2);
 
 // triangulation method5
 // Based on Angular Errors - https://arxiv.org/abs/1903.09115
 // L_inf triangulation
-Vec3 Triangulate5(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2);
+Vec3 LinfAngular(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2);
 
 // Check cheirality error for above methods
 void check_cheirality(const Vec3 &z, const Vec3 &t, const Vec3 &f1_prime, const Vec3 &Rf0_prime);

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -42,11 +42,11 @@ template <typename T> void MakePtrVectorUnique(std::vector<T *> &v) {
 // g12: 2->1
 // xc1: camera coordinates in frame 1
 // xc2: camera coordiantes in frame 2
-bool DirectLinearTransformSVD(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2, Vec3 &x);
+bool DirectLinearTransformSVD(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2, Vec3 &X);
 
 // triangulation method2
 // interface same as triangulation method1 above
-bool DirectLinearTransformAvg(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2, Vec3 &x);
+bool DirectLinearTransformAvg(const SE3 &g12, const Vec2 &xc1, const Vec2 &xc2, Vec3 &X);
 
 // triangulation method3
 // Based on Angular Errors - https://arxiv.org/abs/1903.09115

--- a/src/options.h
+++ b/src/options.h
@@ -3,6 +3,7 @@
 // Author: Xiaohan Fei (feixh@cs.ucla.edu)
 #pragma once
 #include "core.h"
+#include <string>
 
 namespace xivo {
 // depth refinement options
@@ -32,9 +33,9 @@ struct SubfilterOptions {
 
 // options for depth triangulation
 struct TriangulateOptions {
-  TriangulateOptions() : method{1}, zmin{0.05}, zmax{5.0} {}
+  TriangulateOptions() : method{"linf_angular"}, zmin{0.05}, zmax{5.0} {}
 
-  int method;
+  std::string method;
   number_t zmin, zmax;
 };
 

--- a/src/options.h
+++ b/src/options.h
@@ -33,10 +33,11 @@ struct SubfilterOptions {
 
 // options for depth triangulation
 struct TriangulateOptions {
-  TriangulateOptions() : method{"linf_angular"}, zmin{0.05}, zmax{5.0} {}
+  TriangulateOptions() : method{"linf_angular"}, zmin{0.05}, zmax{5.0}, max_theta_thresh{0.01}, beta_thesh{1e-8} {}
 
   std::string method;
   number_t zmin, zmax;
+  number_t max_theta_thresh, beta_thesh; // thresholds for angular reprojection error and parallax error 
 };
 
 struct Criteria {

--- a/src/test/unittest_triangulation.cpp
+++ b/src/test/unittest_triangulation.cpp
@@ -1,0 +1,117 @@
+#include <gtest/gtest.h>
+#include "helpers.h"
+
+using namespace Eigen;
+using namespace xivo;
+
+#include "core.h"
+#include "math.h"
+
+TEST(Triangulation, Normal_Inputs) {
+
+  /*
+  3D point = (2,3,5)
+
+  Translation = 10
+
+  Rotation = 10 degree around y axis
+  */
+
+  Vec2 xc1{2/5,3/5};
+  Vec2 xc2{-8.7447 / 3.5397,3 / 3.5397};
+
+  Mat34 pose;
+
+  pose << 0.9849,0,-0.17310,10,
+          0,1,0,0,
+          0.17310	,0,0.9849,0;
+
+  SE3 g12{pose};
+
+  Vec3 Xc1;
+  
+  Xc1 = L1Angular(g12, xc1, xc2);
+
+  EXPECT_LE((Xc1[2] - 3.5397),1);
+}
+
+
+
+TEST(Triangulation, Parallax) {
+
+  Vec2 xc1{2.2,0.7};
+  Vec2 xc2{3,0.8};
+
+  Mat34 pose;
+  pose << 0.996,0,-0.087,-0.9961,
+          0,1,0,0,
+          0.087,0,0.9961,-0.087;
+
+  SE3 g12{pose};
+
+  Vec3 Xc1;
+  
+  Xc1 = L1Angular(g12, xc1, xc2);
+
+  EXPECT_FLOAT_EQ(0, 0);
+}
+
+
+TEST(Triangulation, Cheirality) {
+
+  Vec2 xc1{2,-0.77};
+  Vec2 xc2{-5,-1.77};
+
+  Mat34 pose;
+  pose << -1,0,0,3,
+          0,1,0,0,
+          0,0,-1,0;
+
+  SE3 g12{pose};
+
+  Vec3 Xc1;
+  
+  Xc1 = L1Angular(g12, xc1, xc2);
+
+  EXPECT_FLOAT_EQ(0, 0);
+}
+
+TEST(Triangulation, Angular_Reprojection_Error) {
+
+Vec2 xc1{2.22216,0.778023};
+  Vec2 xc2{5.22216,1.778023};
+
+  Mat34 pose;
+  pose << 0.707,0,-0.707,3,
+             0,1,0,1,
+             0.707,0,0.707,0;
+
+  SE3 g12{pose};
+
+  Vec3 Xc1;
+  
+  Xc1 = L1Angular(g12, xc1, xc2);
+
+  EXPECT_FLOAT_EQ(0, 0);
+}
+
+
+
+TEST(Triangulation, Vanishing_Point) {
+
+  Vec2 xc1{2,3};
+  Vec2 xc2{2,3};
+
+  Mat34 pose;
+  pose << 1,0,0,-3,
+          0,1,0,0,
+          0,0,1,0;
+
+  SE3 g12{pose};
+
+  Vec3 Xc1;
+  
+  Xc1 = L1Angular(g12, xc1, xc2);
+
+  EXPECT_TRUE(isnan(Xc1[2]));
+}

--- a/src/test/unittest_triangulation.cpp
+++ b/src/test/unittest_triangulation.cpp
@@ -73,9 +73,9 @@ TEST_F(Triangulation, Parallax) {
 
   Mat4 g21;
 
-  g21 << 0.999444,0,-0.03399,-0.99944,
+  g21 << 0.9998,0,0.01745,-0.01,
         0,1,0,0,
-        	0.033991,0,0.999444,	-0.033991,
+        -0.01745,0,0.9998,0,
         0,0,0,1;
 
   Vec4 Xc2_homo = g21 * Xc1_homo;
@@ -184,13 +184,33 @@ TEST_F(Triangulation, Angular_Reprojection_Error) {
 
 TEST_F(Triangulation, Vanishing_Point) {
 
-  Vec2 xc1{2,3};
-  Vec2 xc2{2,3};
+  Vec2 xc1{0.2, 0.3};
+  float z1 = 6000;
+
+  Vec4 Xc1_homo{xc1[0] * z1, xc1[1] * z1, z1, 1};
+
+  Mat4 g21;
+
+  g21 << 1,0,0,-0.1,
+        0,1,0,0,
+        0,0,1,0,
+        0,0,0,1;
+
+  Vec4 Xc2_homo = g21 * Xc1_homo;
+
+  float z2 = Xc2_homo[2];
+
+  Vec2 xc2{Xc2_homo[0]/Xc2_homo[2], Xc2_homo[1]/Xc2_homo[2]};
+
+  Mat4 pose_homo;
+
+  pose_homo = g21.inverse();
 
   Mat34 pose;
-  pose << 1,0,0,-3,
-          0,1,0,0,
-          0,0,1,0;
+
+  pose << pose_homo.coeff(0,0),pose_homo.coeff(0,1),pose_homo.coeff(0,2),pose_homo.coeff(0,3),
+          pose_homo.coeff(1,0),pose_homo.coeff(1,1),pose_homo.coeff(1,2),pose_homo.coeff(1,3),
+          pose_homo.coeff(2,0),pose_homo.coeff(2,1),pose_homo.coeff(2,2),pose_homo.coeff(2,3);
 
   SE3 g12{pose};
 
@@ -199,6 +219,5 @@ TEST_F(Triangulation, Vanishing_Point) {
   bool return_output = L1Angular(g12, xc1, xc2, Xc1, max_theta_thresh, beta_thresh);
 
   EXPECT_FALSE(return_output);
-  EXPECT_TRUE(isnan(Xc1[2]));
 
 }

--- a/src/test/unittest_triangulation.cpp
+++ b/src/test/unittest_triangulation.cpp
@@ -7,8 +7,14 @@ using namespace xivo;
 #include "core.h"
 #include "math.h"
 
-TEST(Triangulation, Normal_Inputs) {
+class Triangulation : public :: testing :: Test
+{
+  protected:
+    float max_theta_thresh = 0.1 * M_PI / 180;
+    float beta_thresh = 0.25 * M_PI / 180;
+};
 
+TEST_F(Triangulation, Normal_Inputs) {
   /*
   3D point = (2,3,5)
 
@@ -18,9 +24,9 @@ TEST(Triangulation, Normal_Inputs) {
   */
 
   Vec2 xc1{0.4, 0.6};
-  int depth = 5;
+  float z1 = 5;
 
-  Vec4 xc1_homo{xc1[0] * depth, xc1[1] * depth, depth, 1};
+  Vec4 Xc1_homo{xc1[0] * z1, xc1[1] * z1, z1, 1};
 
   Mat4 g21;
 
@@ -29,11 +35,11 @@ TEST(Triangulation, Normal_Inputs) {
         -0.17310,0,0.98490,1.73101,
         0,0,0,1;
 
-  Vec4 xc2_homo = g21 * xc1_homo;
+  Vec4 Xc2_homo = g21 * Xc1_homo;
 
-  int new_depth = xc2_homo[2];
+  float z2 = Xc2_homo[2];
 
-  Vec2 xc2{xc2_homo[0]/xc2_homo[2], xc2_homo[1]/xc2_homo[2]};
+  Vec2 xc2{Xc2_homo[0]/Xc2_homo[2], Xc2_homo[1]/Xc2_homo[2]};
 
   Mat4 pose_homo;
 
@@ -49,21 +55,21 @@ TEST(Triangulation, Normal_Inputs) {
 
   Vec3 Xc1;
 
-  bool return_output = L1Angular(g12, xc1, xc2, Xc1);
+  bool return_output = L1Angular(g12, xc1, xc2, Xc1, max_theta_thresh, beta_thresh);
 
   EXPECT_TRUE(return_output);
-  EXPECT_LE((Xc1[2] - new_depth), 1);
+  EXPECT_LE((Xc1[2] - z2), 1);
 
 }
 
 
 
-TEST(Triangulation, Parallax) {
+TEST_F(Triangulation, Parallax) {
 
   Vec2 xc1{2.2, 0.7};
-  int depth = 5;
+  float z1 = 5;
 
-  Vec4 xc1_homo{xc1[0] * depth, xc1[1] * depth, depth, 1};
+  Vec4 Xc1_homo{xc1[0] * z1, xc1[1] * z1, z1, 1};
 
   Mat4 g21;
 
@@ -72,11 +78,9 @@ TEST(Triangulation, Parallax) {
         	0.033991,0,0.999444,	-0.033991,
         0,0,0,1;
 
-  Vec4 xc2_homo = g21 * xc1_homo;
+  Vec4 Xc2_homo = g21 * Xc1_homo;
 
-  int new_depth = xc2_homo[2];
-
-  Vec2 xc2{xc2_homo[0]/xc2_homo[2], xc2_homo[1]/xc2_homo[2]};
+  Vec2 xc2{Xc2_homo[0]/Xc2_homo[2], Xc2_homo[1]/Xc2_homo[2]};
 
   Mat4 pose_homo;
 
@@ -91,19 +95,19 @@ TEST(Triangulation, Parallax) {
   SE3 g12{pose};
 
   Vec3 Xc1;
-  bool return_output = L1Angular(g12, xc1, xc2, Xc1);
+  bool return_output = L1Angular(g12, xc1, xc2, Xc1, max_theta_thresh, beta_thresh);
 
   EXPECT_FALSE(return_output);
 
 }
 
 
-TEST(Triangulation, Cheirality) {
+TEST_F(Triangulation, Cheirality) {
 
   Vec2 xc1{2, -0.77};
-  int depth = 5;
+  float z1 = 5;
 
-  Vec4 xc1_homo{xc1[0] * depth, xc1[1] * depth, depth, 1};
+  Vec4 Xc1_homo{xc1[0] * z1, xc1[1] * z1, z1, 1};
 
   Mat4 g21;
 
@@ -112,11 +116,9 @@ TEST(Triangulation, Cheirality) {
         0,0,-1,0,
         0,0,0,1;
 
-  Vec4 xc2_homo = g21 * xc1_homo;
+  Vec4 Xc2_homo = g21 * Xc1_homo;
 
-  int new_depth = xc2_homo[2];
-
-  Vec2 xc2{xc2_homo[0]/xc2_homo[2], xc2_homo[1]/xc2_homo[2]};
+  Vec2 xc2{Xc2_homo[0]/Xc2_homo[2], Xc2_homo[1]/Xc2_homo[2]};
 
   Mat4 pose_homo;
 
@@ -132,18 +134,18 @@ TEST(Triangulation, Cheirality) {
 
   Vec3 Xc1;
 
-  bool return_output = L1Angular(g12, xc1, xc2, Xc1);
+  bool return_output = L1Angular(g12, xc1, xc2, Xc1, max_theta_thresh, beta_thresh);
 
   EXPECT_FALSE(return_output);
 
 }
 
-TEST(Triangulation, Angular_Reprojection_Error) {
+TEST_F(Triangulation, Angular_Reprojection_Error) {
 
   Vec2 xc1{2.22216, 0.778023};
-  int depth = 5;
+  float z1 = 5;
 
-  Vec4 xc1_homo{xc1[0] * depth, xc1[1] * depth, depth, 1};
+  Vec4 Xc1_homo{xc1[0] * z1, xc1[1] * z1, z1, 1};
 
   Mat4 g21;
 
@@ -152,12 +154,11 @@ TEST(Triangulation, Angular_Reprojection_Error) {
         0,0,1,0,
         0,0,0,1;
 
-  Vec4 xc2_homo = g21 * xc1_homo;
+  Vec4 Xc2_homo = g21 * Xc1_homo;
 
-  int new_depth = xc2_homo[2];
   float noise = 0.7;
 
-  Vec2 xc2{xc2_homo[0]/xc2_homo[2] + noise, xc2_homo[1]/xc2_homo[2] + noise};
+  Vec2 xc2{Xc2_homo[0]/Xc2_homo[2] + noise, Xc2_homo[1]/Xc2_homo[2] + noise};
 
   Mat4 pose_homo;
 
@@ -173,7 +174,7 @@ TEST(Triangulation, Angular_Reprojection_Error) {
 
   Vec3 Xc1;
 
-  bool return_output = L1Angular(g12, xc1, xc2, Xc1);
+  bool return_output = L1Angular(g12, xc1, xc2, Xc1, max_theta_thresh, beta_thresh);
 
   EXPECT_FALSE(return_output);
 
@@ -181,7 +182,7 @@ TEST(Triangulation, Angular_Reprojection_Error) {
 
 
 
-TEST(Triangulation, Vanishing_Point) {
+TEST_F(Triangulation, Vanishing_Point) {
 
   Vec2 xc1{2,3};
   Vec2 xc2{2,3};
@@ -195,7 +196,7 @@ TEST(Triangulation, Vanishing_Point) {
 
   Vec3 Xc1;
 
-  bool return_output = L1Angular(g12, xc1, xc2, Xc1);
+  bool return_output = L1Angular(g12, xc1, xc2, Xc1, max_theta_thresh, beta_thresh);
 
   EXPECT_FALSE(return_output);
   EXPECT_TRUE(isnan(Xc1[2]));

--- a/src/test/unittest_triangulation.cpp
+++ b/src/test/unittest_triangulation.cpp
@@ -17,82 +17,166 @@ TEST(Triangulation, Normal_Inputs) {
   Rotation = 10 degree around y axis
   */
 
-  Vec2 xc1{2/5,3/5};
-  Vec2 xc2{-8.7447 / 3.5397,3 / 3.5397};
+  Vec2 xc1{0.4, 0.6};
+  int depth = 5;
+
+  Vec4 xc1_homo{xc1[0] * depth, xc1[1] * depth, depth, 1};
+
+  Mat4 g21;
+
+  g21 << 0.9849082,0,0.1731,-9.8490,
+        0,1,0,0,
+        -0.17310,0,0.98490,1.73101,
+        0,0,0,1;
+
+  Vec4 xc2_homo = g21 * xc1_homo;
+
+  int new_depth = xc2_homo[2];
+
+  Vec2 xc2{xc2_homo[0]/xc2_homo[2], xc2_homo[1]/xc2_homo[2]};
+
+  Mat4 pose_homo;
+
+  pose_homo = g21.inverse();
 
   Mat34 pose;
 
-  pose << 0.9849,0,-0.17310,10,
-          0,1,0,0,
-          0.17310	,0,0.9849,0;
+  pose << pose_homo.coeff(0,0),pose_homo.coeff(0,1),pose_homo.coeff(0,2),pose_homo.coeff(0,3),
+          pose_homo.coeff(1,0),pose_homo.coeff(1,1),pose_homo.coeff(1,2),pose_homo.coeff(1,3),
+          pose_homo.coeff(2,0),pose_homo.coeff(2,1),pose_homo.coeff(2,2),pose_homo.coeff(2,3);
 
   SE3 g12{pose};
 
   Vec3 Xc1;
-  
-  Xc1 = L1Angular(g12, xc1, xc2);
 
-  EXPECT_LE((Xc1[2] - 3.5397),1);
+  bool return_output = L1Angular(g12, xc1, xc2, Xc1);
+
+  EXPECT_TRUE(return_output);
+  EXPECT_LE((Xc1[2] - new_depth), 1);
+
 }
 
 
 
 TEST(Triangulation, Parallax) {
 
-  Vec2 xc1{2.2,0.7};
-  Vec2 xc2{3,0.8};
+  Vec2 xc1{2.2, 0.7};
+  int depth = 5;
+
+  Vec4 xc1_homo{xc1[0] * depth, xc1[1] * depth, depth, 1};
+
+  Mat4 g21;
+
+  g21 << 0.999444,0,-0.03399,-0.99944,
+        0,1,0,0,
+        	0.033991,0,0.999444,	-0.033991,
+        0,0,0,1;
+
+  Vec4 xc2_homo = g21 * xc1_homo;
+
+  int new_depth = xc2_homo[2];
+
+  Vec2 xc2{xc2_homo[0]/xc2_homo[2], xc2_homo[1]/xc2_homo[2]};
+
+  Mat4 pose_homo;
+
+  pose_homo = g21.inverse();
 
   Mat34 pose;
-  pose << 0.996,0,-0.087,-0.9961,
-          0,1,0,0,
-          0.087,0,0.9961,-0.087;
+
+  pose << pose_homo.coeff(0,0),pose_homo.coeff(0,1),pose_homo.coeff(0,2),pose_homo.coeff(0,3),
+          pose_homo.coeff(1,0),pose_homo.coeff(1,1),pose_homo.coeff(1,2),pose_homo.coeff(1,3),
+          pose_homo.coeff(2,0),pose_homo.coeff(2,1),pose_homo.coeff(2,2),pose_homo.coeff(2,3);
 
   SE3 g12{pose};
 
   Vec3 Xc1;
-  
-  Xc1 = L1Angular(g12, xc1, xc2);
+  bool return_output = L1Angular(g12, xc1, xc2, Xc1);
 
-  EXPECT_FLOAT_EQ(0, 0);
+  EXPECT_FALSE(return_output);
+
 }
 
 
 TEST(Triangulation, Cheirality) {
 
-  Vec2 xc1{2,-0.77};
-  Vec2 xc2{-5,-1.77};
+  Vec2 xc1{2, -0.77};
+  int depth = 5;
+
+  Vec4 xc1_homo{xc1[0] * depth, xc1[1] * depth, depth, 1};
+
+  Mat4 g21;
+
+  g21 << -1,0,0,3,
+        0,1,0,0,
+        0,0,-1,0,
+        0,0,0,1;
+
+  Vec4 xc2_homo = g21 * xc1_homo;
+
+  int new_depth = xc2_homo[2];
+
+  Vec2 xc2{xc2_homo[0]/xc2_homo[2], xc2_homo[1]/xc2_homo[2]};
+
+  Mat4 pose_homo;
+
+  pose_homo = g21.inverse();
 
   Mat34 pose;
-  pose << -1,0,0,3,
-          0,1,0,0,
-          0,0,-1,0;
+
+  pose << pose_homo.coeff(0,0),pose_homo.coeff(0,1),pose_homo.coeff(0,2),pose_homo.coeff(0,3),
+          pose_homo.coeff(1,0),pose_homo.coeff(1,1),pose_homo.coeff(1,2),pose_homo.coeff(1,3),
+          pose_homo.coeff(2,0),pose_homo.coeff(2,1),pose_homo.coeff(2,2),pose_homo.coeff(2,3);
 
   SE3 g12{pose};
 
   Vec3 Xc1;
-  
-  Xc1 = L1Angular(g12, xc1, xc2);
 
-  EXPECT_FLOAT_EQ(0, 0);
+  bool return_output = L1Angular(g12, xc1, xc2, Xc1);
+
+  EXPECT_FALSE(return_output);
+
 }
 
 TEST(Triangulation, Angular_Reprojection_Error) {
 
-Vec2 xc1{2.22216,0.778023};
-  Vec2 xc2{5.22216,1.778023};
+  Vec2 xc1{2.22216, 0.778023};
+  int depth = 5;
+
+  Vec4 xc1_homo{xc1[0] * depth, xc1[1] * depth, depth, 1};
+
+  Mat4 g21;
+
+  g21 << 1,0,0,3,
+        0,1,0,0,
+        0,0,1,0,
+        0,0,0,1;
+
+  Vec4 xc2_homo = g21 * xc1_homo;
+
+  int new_depth = xc2_homo[2];
+  float noise = 0.7;
+
+  Vec2 xc2{xc2_homo[0]/xc2_homo[2] + noise, xc2_homo[1]/xc2_homo[2] + noise};
+
+  Mat4 pose_homo;
+
+  pose_homo = g21.inverse();
 
   Mat34 pose;
-  pose << 0.707,0,-0.707,3,
-             0,1,0,1,
-             0.707,0,0.707,0;
+
+  pose << pose_homo.coeff(0,0),pose_homo.coeff(0,1),pose_homo.coeff(0,2),pose_homo.coeff(0,3),
+          pose_homo.coeff(1,0),pose_homo.coeff(1,1),pose_homo.coeff(1,2),pose_homo.coeff(1,3),
+          pose_homo.coeff(2,0),pose_homo.coeff(2,1),pose_homo.coeff(2,2),pose_homo.coeff(2,3);
 
   SE3 g12{pose};
 
   Vec3 Xc1;
-  
-  Xc1 = L1Angular(g12, xc1, xc2);
 
-  EXPECT_FLOAT_EQ(0, 0);
+  bool return_output = L1Angular(g12, xc1, xc2, Xc1);
+
+  EXPECT_FALSE(return_output);
+
 }
 
 
@@ -110,8 +194,10 @@ TEST(Triangulation, Vanishing_Point) {
   SE3 g12{pose};
 
   Vec3 Xc1;
-  
-  Xc1 = L1Angular(g12, xc1, xc2);
 
+  bool return_output = L1Angular(g12, xc1, xc2, Xc1);
+
+  EXPECT_FALSE(return_output);
   EXPECT_TRUE(isnan(Xc1[2]));
+
 }

--- a/src/test/unittest_triangulation.cpp
+++ b/src/test/unittest_triangulation.cpp
@@ -56,9 +56,17 @@ TEST_F(Triangulation, Normal_Inputs) {
   Vec3 Xc1;
 
   bool return_output = L1Angular(g12, xc1, xc2, Xc1, max_theta_thresh, beta_thresh);
-
   EXPECT_TRUE(return_output);
   EXPECT_LE((Xc1[2] - z2), 1);
+
+  return_output = L2Angular(g12, xc1, xc2, Xc1, max_theta_thresh, beta_thresh);
+  EXPECT_TRUE(return_output);
+  EXPECT_LE((Xc1[2] - z2), 1);
+
+  return_output = LinfAngular(g12, xc1, xc2, Xc1, max_theta_thresh, beta_thresh);
+  EXPECT_TRUE(return_output);
+  EXPECT_LE((Xc1[2] - z2), 1);
+
 
 }
 
@@ -96,7 +104,12 @@ TEST_F(Triangulation, Parallax) {
 
   Vec3 Xc1;
   bool return_output = L1Angular(g12, xc1, xc2, Xc1, max_theta_thresh, beta_thresh);
+  EXPECT_FALSE(return_output);
 
+  return_output = L2Angular(g12, xc1, xc2, Xc1, max_theta_thresh, beta_thresh);
+  EXPECT_FALSE(return_output);
+
+  return_output = LinfAngular(g12, xc1, xc2, Xc1, max_theta_thresh, beta_thresh);
   EXPECT_FALSE(return_output);
 
 }
@@ -135,7 +148,12 @@ TEST_F(Triangulation, Cheirality) {
   Vec3 Xc1;
 
   bool return_output = L1Angular(g12, xc1, xc2, Xc1, max_theta_thresh, beta_thresh);
+  EXPECT_FALSE(return_output);
 
+  return_output = L2Angular(g12, xc1, xc2, Xc1, max_theta_thresh, beta_thresh);
+  EXPECT_FALSE(return_output);
+
+  return_output = LinfAngular(g12, xc1, xc2, Xc1, max_theta_thresh, beta_thresh);
   EXPECT_FALSE(return_output);
 
 }
@@ -175,7 +193,12 @@ TEST_F(Triangulation, Angular_Reprojection_Error) {
   Vec3 Xc1;
 
   bool return_output = L1Angular(g12, xc1, xc2, Xc1, max_theta_thresh, beta_thresh);
+  EXPECT_FALSE(return_output);
 
+  return_output = L2Angular(g12, xc1, xc2, Xc1, max_theta_thresh, beta_thresh);
+  EXPECT_FALSE(return_output);
+
+  return_output = LinfAngular(g12, xc1, xc2, Xc1, max_theta_thresh, beta_thresh);
   EXPECT_FALSE(return_output);
 
 }
@@ -217,7 +240,12 @@ TEST_F(Triangulation, Vanishing_Point) {
   Vec3 Xc1;
 
   bool return_output = L1Angular(g12, xc1, xc2, Xc1, max_theta_thresh, beta_thresh);
+  EXPECT_FALSE(return_output);
 
+  return_output = L2Angular(g12, xc1, xc2, Xc1, max_theta_thresh, beta_thresh);
+  EXPECT_FALSE(return_output);
+
+  return_output = LinfAngular(g12, xc1, xc2, Xc1, max_theta_thresh, beta_thresh);
   EXPECT_FALSE(return_output);
 
 }

--- a/src/test/unittest_triangulation.cpp
+++ b/src/test/unittest_triangulation.cpp
@@ -12,6 +12,7 @@ class Triangulation : public :: testing :: Test
   protected:
     float max_theta_thresh = 0.1 * M_PI / 180;
     float beta_thresh = 0.25 * M_PI / 180;
+    float eps = 0.5;
 };
 
 TEST_F(Triangulation, Normal_Inputs) {
@@ -37,8 +38,6 @@ TEST_F(Triangulation, Normal_Inputs) {
 
   Vec4 Xc2_homo = g21 * Xc1_homo;
 
-  float z2 = Xc2_homo[2];
-
   Vec2 xc2{Xc2_homo[0]/Xc2_homo[2], Xc2_homo[1]/Xc2_homo[2]};
 
   Mat4 pose_homo;
@@ -57,17 +56,16 @@ TEST_F(Triangulation, Normal_Inputs) {
 
   bool return_output = L1Angular(g12, xc1, xc2, Xc1, max_theta_thresh, beta_thresh);
   EXPECT_TRUE(return_output);
-  EXPECT_LE((Xc1[2] - z2), 1);
+  EXPECT_LE(abs(Xc1[2] - z1), eps);
+
 
   return_output = L2Angular(g12, xc1, xc2, Xc1, max_theta_thresh, beta_thresh);
   EXPECT_TRUE(return_output);
-  EXPECT_LE((Xc1[2] - z2), 1);
+  EXPECT_LE(abs(Xc1[2] - z1), eps);
 
   return_output = LinfAngular(g12, xc1, xc2, Xc1, max_theta_thresh, beta_thresh);
   EXPECT_TRUE(return_output);
-  EXPECT_LE((Xc1[2] - z2), 1);
-
-
+  EXPECT_LE(abs(Xc1[2] - z1), eps);
 }
 
 
@@ -192,12 +190,16 @@ TEST_F(Triangulation, Angular_Reprojection_Error) {
 
   Vec3 Xc1;
 
-  bool return_output = L1Angular(g12, xc1, xc2, Xc1, max_theta_thresh, beta_thresh);
-  EXPECT_FALSE(return_output);
-
   // NOTE (April 2022): On Arch Linux (gcc11) and Ubuntu 20.04 (gcc9), this test
   // (for L1Angular) fails when compiled in RELEASE mode but passes when
   // compiled in DEBUG mode.
+  bool return_output = L1Angular(g12, xc1, xc2, Xc1, max_theta_thresh, beta_thresh);
+  EXPECT_FALSE(return_output);
+
+  return_output = L2Angular(g12, xc1, xc2, Xc1, max_theta_thresh, beta_thresh);
+  EXPECT_FALSE(return_output);
+
+  return_output = LinfAngular(g12, xc1, xc2, Xc1, max_theta_thresh, beta_thresh);
   EXPECT_FALSE(return_output);
 
 }

--- a/src/test/unittest_triangulation.cpp
+++ b/src/test/unittest_triangulation.cpp
@@ -176,6 +176,9 @@ TEST_F(Triangulation, Angular_Reprojection_Error) {
 
   bool return_output = L1Angular(g12, xc1, xc2, Xc1, max_theta_thresh, beta_thresh);
 
+  // NOTE (April 2022): On Arch Linux (gcc11) and Ubuntu 20.04 (gcc9), this test
+  // (for L1Angular) fails when compiled in RELEASE mode but passes when
+  // compiled in DEBUG mode.
   EXPECT_FALSE(return_output);
 
 }


### PR DESCRIPTION
I have added the triangulation methods. To use different methods, change the method number in config file to following numbers-
3 - l1 triangulation
4 - l2 triangulation
5 - l_inf triangulation 

The benchmarks results are - 

L1
absolute_translational_error.rmse 0.048211 m
translational_error.rmse 0.021485 m
rotational_error.rmse 0.525738 deg

L2
absolute_translational_error.rmse 0.046309 m
translational_error.rmse 0.023607 m
rotational_error.rmse 0.525261 deg

L_inf
absolute_translational_error.rmse 0.047667 m
translational_error.rmse 0.019832 m
rotational_error.rmse 0.524616 deg

I also added the functions to check for cheirality, angular reprojection, and parallax. The epsilon values (randomly chosen by me) are currently hardcoded. Please suggest appropriate values and cleaner way to write it. I have commented the function calls because it keeps throwing cheirality and parallax errors.

