### PR TITLE
random shuffle fix

### DIFF
--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -299,7 +299,7 @@ std::vector<FeaturePtr> Graph::FindNewGaugeFeatures(GroupPtr g) {
       new_gauge_features_for_g = fill_slots(g, candidates);
       if (gauge_features_[g].size() >= 3) {
         if (collinear_check(gauge_features_[g], collinear_cross_prod_thresh)) {
-          std::random_shuffle(candidates.begin(), candidates.end());
+          std::shuffle(candidates.begin(), candidates.end(), *random_generator);
           if (NT==9) {
             LOG(WARNING) << "Did not find a set of non-collinear features. defaulting to using those with smallest covariance";
             gauge_features_[g] = gauge_features_backup;

--- a/src/graph.h
+++ b/src/graph.h
@@ -19,6 +19,10 @@ class Graph : public GraphBase {
 public:
   static Graph* Create();
   static Graph* instance();
+  ~Graph() {
+    delete random_generator;
+    delete random_device;
+  }
 
   void RemoveFeature(const FeaturePtr f);
   void RemoveFeatures(const std::vector<FeaturePtr> &);
@@ -93,7 +97,11 @@ public:
   std::vector<FeaturePtr> FindNewGaugeFeatures(GroupPtr g);
 
 private:
-  Graph() = default;
+  Graph() {
+    random_device = new std::random_device;
+    random_generator = new std::mt19937((*random_device)());
+  }
+
   Graph(const Graph&) = delete;
   Graph& operator=(const Graph&) = delete;
   static std::unique_ptr<Graph> instance_;
@@ -103,6 +111,10 @@ private:
   /** Maps group id (int) to a unordered set of features whose (x,y) coordinates
    *  of `Feature::x_` is held constant. */
   std::unordered_map<GroupPtr, std::unordered_set<FeaturePtr>> gauge_features_;
+
+  /** For generating random permutations in `FindNewGaugeFeatures` */
+  std::random_device *random_device;
+  std::mt19937 *random_generator;
 };
 
 } // namespace xivo


### PR DESCRIPTION
replace deprecated std::random_shuffle with std::shuffle. For some reason gcc did not remove random_shuffle but clang did

@agrawalparth10, test and make sure XIVO still runs (with logging enabled). I saw the warning once for sequence `data9_workbench`